### PR TITLE
[RFC] Support for emulator discovery

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,6 +17,7 @@ allprojects {
         kotlinOptions {
             jvmTarget = "1.8"
             freeCompilerArgs += "-Xopt-in=kotlin.ExperimentalUnsignedTypes"
+            freeCompilerArgs += "-Xjvm-default=all"
         }
     }
     pluginManager.withPlugin("com.vanniktech.maven.publish") {

--- a/dadb/build.gradle.kts
+++ b/dadb/build.gradle.kts
@@ -18,10 +18,11 @@ repositories {
 }
 
 dependencies {
-    api("com.squareup.okio:okio:2.10.0")
+    api("com.squareup.okio:okio:3.0.0")
     implementation(platform("org.jetbrains.kotlin:kotlin-bom"))
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
 
+    testImplementation("com.squareup.okio:okio-fakefilesystem:3.0.0")
     testImplementation("org.jetbrains.kotlin:kotlin-test")
     testImplementation("com.google.truth:truth:1.0.1")
 }

--- a/dadb/src/main/kotlin/dadb/devices/Device.kt
+++ b/dadb/src/main/kotlin/dadb/devices/Device.kt
@@ -1,0 +1,12 @@
+package dadb.devices
+
+sealed interface Device {
+  val id: String
+  val deviceClass: DeviceClass?
+  val serialPort: Int
+  val adbPort: Int
+
+  enum class DeviceClass {
+    Mobile, Wear, TV, Auto
+  }
+}

--- a/dadb/src/main/kotlin/dadb/devices/DeviceFinder.kt
+++ b/dadb/src/main/kotlin/dadb/devices/DeviceFinder.kt
@@ -1,0 +1,74 @@
+package dadb.devices
+
+import com.sun.security.auth.module.UnixSystem
+import dadb.devices.Emulator.Companion.toEmulator
+import okio.FileSystem
+import okio.Path
+import okio.Path.Companion.toPath
+
+class DeviceFinder(
+  val registrationDirectory: Path = findRegistrationDirectory(),
+  val fileSystem: FileSystem = FileSystem.SYSTEM
+) {
+  fun findEmulators(): List<Emulator> {
+    return fileSystem.list(registrationDirectory).filter {
+      it.name.matches(fileRegex)
+    }.map { parseFile(it) }
+  }
+
+  private fun parseFile(it: Path): Emulator {
+    return fileSystem.read(it) {
+      readUtf8().lines().mapNotNull {
+        val parts = it.split("=", limit = 2)
+        if (parts.size == 2) {
+          parts[0] to parts[1]
+        } else {
+          null
+        }
+      }
+    }.toMap().toEmulator()
+  }
+
+  companion object {
+    val fileRegex = "pid_\\d+.ini".toRegex()
+
+    private val os = System.getProperty("os.name").lowercase()
+
+    // https://cs.android.com/android-studio/platform/tools/base/+/mirror-goog-studio-main:utp/android-test-plugin-host-retention/src/main/java/com/android/tools/utp/plugins/host/icebox/IceboxConfigUtils.kt?q=8554%20f:android
+    fun findRegistrationDirectory() = when {
+      os.startsWith("mac") -> macPath()
+      os.startsWith("win") -> windowsPath()
+      else -> linuxPath()
+    } / "avd" / "running"
+
+    private fun linuxPath(): Path {
+      val possible = listOfNotNull(
+        System.getenv("XDG_RUNTIME_DIR"),
+        uid()?.let { "/run/user/$it" },
+        System.getenv("ANDROID_EMULATOR_HOME"),
+        System.getenv("ANDROID_PREFS_ROOT"),
+        System.getenv("ANDROID_SDK_HOME"),
+        (System.getenv("HOME") ?: "/") + ".android",
+        System.getProperty("android.emulator.home")
+      ).map { it.toPath() }
+
+      possible.forEach {
+        if (FileSystem.SYSTEM.metadataOrNull(it)?.isDirectory == true) {
+          return it
+        }
+      }
+
+      return (FileSystem.SYSTEM_TEMPORARY_DIRECTORY / ("android-" + System.getProperty("USER")))
+    }
+
+    private fun uid() = try {
+      UnixSystem().uid
+    } catch (t: Throwable) {
+      null
+    }
+
+    private fun windowsPath() = (System.getenv("LOCALAPPDATA") ?: "/").toPath() / "Temp"
+
+    private fun macPath() = (System.getenv("HOME") ?: "/").toPath() / "Library" / "Caches" / "TemporaryItems"
+  }
+}

--- a/dadb/src/main/kotlin/dadb/devices/Emulator.kt
+++ b/dadb/src/main/kotlin/dadb/devices/Emulator.kt
@@ -1,0 +1,36 @@
+package dadb.devices
+
+import okio.Path
+import okio.Path.Companion.toPath
+
+data class Emulator(
+    override val id: String,
+    override val deviceClass: Device.DeviceClass?,
+    override val serialPort: Int,
+    override val adbPort: Int,
+    val avdDir: Path,
+    val grpcPort: Int?,
+    val cmdline: String?
+) : Device {
+
+  // port.serial=5554
+  // port.adb=5555
+  // avd.name=Wear_30_2
+  // avd.dir=.android/avd/Wear_30_2.avd
+  // avd.id=Wear_30_2
+  // cmdline="emulator/qemu/darwin-x86_64/qemu-system-x86_64" "-avd" "Wear_30_2"
+  // grpc.port=8554
+  companion object {
+    fun Map<String, String>.toEmulator(): Emulator {
+      return Emulator(
+        id = this["avd.id"]!!,
+        deviceClass = null,
+        serialPort = this["port.serial"]!!.toInt(),
+        adbPort = this["port.adb"]!!.toInt(),
+        avdDir = this["avd.dir"]!!.toPath(),
+        grpcPort = this["grpc.port"]?.toInt(),
+        cmdline = this["cmdline"]
+      )
+    }
+  }
+}

--- a/dadb/src/test/kotlin/dadb/devices/DeviceFinderTest.kt
+++ b/dadb/src/test/kotlin/dadb/devices/DeviceFinderTest.kt
@@ -1,0 +1,45 @@
+package dadb.devices
+
+import okio.Path.Companion.toPath
+import okio.fakefilesystem.FakeFileSystem
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class DeviceFinderTest {
+    val fileSystem = FakeFileSystem()
+    val registrationDirectory = "/avd".toPath()
+    val finder = DeviceFinder(registrationDirectory, fileSystem)
+
+    @Test
+    fun testReadFiles() {
+        fileSystem.createDirectories(registrationDirectory)
+        fileSystem.write(registrationDirectory / "pid_44126.ini") {
+            writeUtf8(
+                """
+                port.serial=5554
+                port.adb=5555
+                avd.name=Pixel
+                avd.dir=/Users/xxx/.android/avd/Pixel.avd
+                avd.id=Pixel
+                cmdline="/Users/xxx/Library/Android/sdk/emulator/qemu/darwin-x86_64/qemu-system-x86_64" "-avd" "Pixel"
+                grpc.port=8554
+                """.trimIndent()
+            )
+        }
+
+        val devices = finder.findEmulators()
+
+        assertEquals(
+            Emulator(
+                id = "Pixel",
+                deviceClass = null,
+                serialPort = 5554,
+                adbPort = 5555,
+                avdDir = "/Users/xxx/.android/avd/Pixel.avd".toPath(),
+                grpcPort = 8554,
+                cmdline = "\"/Users/xxx/Library/Android/sdk/emulator/qemu/darwin-x86_64/qemu-system-x86_64\" \"-avd\" \"Pixel\"",
+            ),
+            devices.single()
+        )
+    }
+}


### PR DESCRIPTION
Not sure if you are taking PRs, or consider this in scope, so no offense taken if you close this.

Ideally I would use host:devices or host:devices-l to find the available emulator and devices.  But I couldn't get that working with Dadb (https://github.com/mobile-dev-inc/dadb/issues/7).

As a shortcut, I read from the avd process files as described here https://cs.android.com/android-studio/platform/tools/base/+/mirror-goog-studio-main:utp/android-test-plugin-host-retention/src/main/java/com/android/tools/utp/plugins/host/icebox/IceboxConfigUtils.kt?q=8554%20f:android 

Original code in https://github.com/yschimke/emulator-tools/commit/96374554160a8707315001796d16f3f8c7f1d25b