### PR TITLE
Adding support for TCP port forwarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,18 @@ assert(response.exitCode == 0)
 assert(response.output == "hello\n")
 ```
 
+### TCP Forwarding
+
+```kotlin
+dadb.tcpForward(
+    hostPort = 7001,
+    targetPort = 7001
+).use {
+    // localhost:7001 is now forwarded to device's 7001 port
+    // Do operations that depend on port forwarding
+}
+```
+
 ### Authentication
 
 **Dadb will use your adb key at `~/.android/adbkey` by default.**

--- a/dadb/src/main/kotlin/dadb/Dadb.kt
+++ b/dadb/src/main/kotlin/dadb/Dadb.kt
@@ -17,6 +17,7 @@
 
 package dadb
 
+import dadb.forwarding.TcpForwarder
 import okio.*
 import java.io.File
 import java.io.IOException
@@ -122,6 +123,14 @@ interface Dadb : AutoCloseable {
             throw IOException("Failed to restart adb as root: $response")
         }
         waitRootOrClose(this, root = false)
+    }
+
+    @Throws(InterruptedException::class)
+    fun tcpForward(hostPort: Int, targetPort: Int): AutoCloseable {
+        val forwarder = TcpForwarder(this, hostPort, targetPort)
+        forwarder.start()
+
+        return forwarder
     }
 
     companion object {

--- a/dadb/src/main/kotlin/dadb/forwarding/TcpForwarder.kt
+++ b/dadb/src/main/kotlin/dadb/forwarding/TcpForwarder.kt
@@ -95,13 +95,13 @@ internal class TcpForwarder(
 
         moveToState(State.STOPPING)
 
+        server?.close()
+        server = null
+        serverThread?.interrupt()
+        serverThread = null
         clientExecutor?.shutdown()
         clientExecutor?.awaitTermination(5, TimeUnit.SECONDS)
         clientExecutor = null
-        serverThread?.interrupt()
-        serverThread = null
-        server?.close()
-        server = null
 
         waitFor(10, 5000) {
             state == State.STOPPED

--- a/dadb/src/main/kotlin/dadb/forwarding/TcpForwarder.kt
+++ b/dadb/src/main/kotlin/dadb/forwarding/TcpForwarder.kt
@@ -1,0 +1,133 @@
+package dadb.forwarding
+
+import dadb.Dadb
+import okio.BufferedSink
+import okio.Source
+import okio.buffer
+import okio.sink
+import okio.source
+import java.io.InterruptedIOException
+import java.net.ServerSocket
+import kotlin.concurrent.thread
+
+internal class TcpForwarder(
+    private val dadb: Dadb,
+    private val hostPort: Int,
+    private val targetPort: Int,
+) : AutoCloseable {
+
+    private var state: State = State.STOPPED
+    private var thread: Thread? = null
+
+    fun start() {
+        if (state != State.STOPPED) {
+            throw IllegalStateException("Forwarder is already started at port $hostPort")
+        }
+
+        moveToState(State.STARTING)
+        thread = thread {
+            try {
+                handleForwarding()
+            } finally {
+                moveToState(State.STOPPED)
+            }
+        }
+
+        waitFor(10, 5000) {
+            state == State.STARTED
+        }
+    }
+
+    private fun handleForwarding() {
+        val adbStream = dadb.open("tcp:$targetPort")
+
+        val server = ServerSocket(hostPort)
+
+        moveToState(State.STARTED)
+
+        val client = server.accept()
+
+        val readerThread = thread {
+            forward(
+                client.getInputStream().source(),
+                adbStream.sink
+            )
+        }
+
+        val writerThread = thread {
+            forward(
+                adbStream.source,
+                client.sink().buffer()
+            )
+        }
+
+        while (!Thread.interrupted()) {
+            try {
+                Thread.sleep(500)
+            } catch (ignored: InterruptedException) {
+                break
+            }
+        }
+
+        readerThread.interrupt()
+        writerThread.interrupt()
+    }
+
+    override fun close() {
+        if (state == State.STOPPED || state == State.STOPPING) {
+            return
+        }
+
+        moveToState(State.STOPPING)
+        thread?.interrupt()
+        thread = null
+
+        waitFor(10, 5000) {
+            state == State.STOPPED
+        }
+    }
+
+    private fun forward(source: Source, sink: BufferedSink) {
+        try {
+            while (!Thread.interrupted()) {
+                source.read(sink.buffer, 256)
+                sink.flush()
+            }
+        } catch (ignored: InterruptedException) {
+            // Do nothing
+        } catch (ignored: InterruptedIOException) {
+            // do nothing
+        }
+    }
+
+    private fun moveToState(state: State) {
+        this.state = state
+    }
+
+    private enum class State {
+        STARTING,
+        STARTED,
+        STOPPING,
+        STOPPED
+    }
+
+    private fun waitFor(intervalMs: Int, timeoutMs: Int, test: () -> Boolean): Boolean {
+        val start = System.currentTimeMillis()
+        var lastCheck = start
+        while (!test()) {
+            val now = System.currentTimeMillis()
+            val timeSinceStart = now - start
+            val timeSinceLastCheck = now - lastCheck
+            if (timeoutMs in 0..timeSinceStart) {
+                return false
+            }
+            val sleepTime = intervalMs - timeSinceLastCheck
+            if (sleepTime > 0) {
+                Thread.sleep(sleepTime)
+            }
+            lastCheck = System.currentTimeMillis()
+        }
+        return true
+    }
+
+}

--- a/dadb/src/test/kotlin/dadb/DadbTest.kt
+++ b/dadb/src/test/kotlin/dadb/DadbTest.kt
@@ -225,7 +225,7 @@ internal class DadbTest : BaseConcurrencyTest() {
     }
 
     @Test
-    fun tcpForward_multipleConsequentConnections() {
+    fun tcpForward_multipleSequentialConnections() {
         localEmulator { dadb ->
             dadb.tcpForward(8888, 8888).use { _ ->
                 val firstFuture = broadcastSingleMessage(dadb, "OK", 8888)


### PR DESCRIPTION
As requested in issue #1 

Usage (Kotlin):

```
dadb.tcpForward(
    hostPort = 7001,
    targetPort = 7001
).use {
    // Do operations that depend on port forwarding
}
```