### PR TITLE
Subclass the shell packets by STDOUT/STDIN/ERR

### DIFF
--- a/dadb/src/test/kotlin/dadb/DadbTest.kt
+++ b/dadb/src/test/kotlin/dadb/DadbTest.kt
@@ -76,7 +76,7 @@ internal class DadbTest : BaseConcurrencyTest() {
                 shellStream.write("echo hello\n")
 
                 val shellPacket = shellStream.read()
-                assertShellPacket(shellPacket, ID_STDOUT, "hello\n")
+                assertShellPacket(shellPacket, AdbShellPacket.StdOut::class.java, "hello\n")
 
                 shellStream.write("exit\n")
 
@@ -95,7 +95,7 @@ internal class DadbTest : BaseConcurrencyTest() {
                     shellStream.write("echo $random\n")
 
                     val shellPacket = shellStream.read()
-                    assertShellPacket(shellPacket, ID_STDOUT, "$random\n")
+                    assertShellPacket(shellPacket, AdbShellPacket.StdOut::class.java, "$random\n")
 
                     shellStream.write("exit\n")
 

--- a/dadb/src/test/kotlin/dadb/TestUtils.kt
+++ b/dadb/src/test/kotlin/dadb/TestUtils.kt
@@ -27,9 +27,9 @@ fun assertShellResponse(shellResponse: AdbShellResponse, exitCode: Int, allOutpu
     Truth.assertThat(shellResponse.exitCode).isEqualTo(exitCode)
 }
 
-fun assertShellPacket(shellPacket: AdbShellPacket, id: Int, payload: String) {
+fun assertShellPacket(shellPacket: AdbShellPacket, packetType: Class<out AdbShellPacket>, payload: String) {
     Truth.assertThat(String(shellPacket.payload)).isEqualTo(payload)
-    Truth.assertThat(shellPacket.id).isEqualTo(id)
+    Truth.assertThat(shellPacket).isInstanceOf(packetType)
 }
 
 fun killServer() {


### PR DESCRIPTION
Making the packets an explicit class type makes it easier to use a `when` statement and handle the use cases. Using an int type means that a consumer would have to use an `else` statement, even though the ID types have already been checked.