### PR TITLE
Fix: use empty byte array if there is no public key

### DIFF
--- a/dadb/src/main/kotlin/dadb/AdbKeyPair.kt
+++ b/dadb/src/main/kotlin/dadb/AdbKeyPair.kt
@@ -73,7 +73,7 @@ class AdbKeyPair(
             val privateKeyFile = File(System.getenv("HOME"), ".android/adbkey")
             val publicKeyFile = File(System.getenv("HOME"), ".android/adbkey.pub")
 
-            if (!privateKeyFile.exists() || !publicKeyFile.exists()) {
+            if (!privateKeyFile.exists()) {
                 generate(privateKeyFile, publicKeyFile)
             }
 
@@ -83,7 +83,11 @@ class AdbKeyPair(
         @JvmStatic
         fun read(privateKeyFile: File, publicKeyFile: File): AdbKeyPair {
             val privateKey = PKCS8.parse(privateKeyFile.readBytes())
-            val publicKeyBytes = readAdbPublicKey(publicKeyFile)
+            val publicKeyBytes = if (publicKeyFile.exists()) {
+                readAdbPublicKey(publicKeyFile)
+            } else {
+                ByteArray(0)
+            }
 
             return AdbKeyPair(privateKey, publicKeyBytes)
         }

--- a/dadb/src/main/kotlin/dadb/AdbKeyPair.kt
+++ b/dadb/src/main/kotlin/dadb/AdbKeyPair.kt
@@ -81,9 +81,10 @@ class AdbKeyPair(
         }
 
         @JvmStatic
-        fun read(privateKeyFile: File, publicKeyFile: File): AdbKeyPair {
+        @JvmOverloads
+        fun read(privateKeyFile: File, publicKeyFile: File? = null): AdbKeyPair {
             val privateKey = PKCS8.parse(privateKeyFile.readBytes())
-            val publicKeyBytes = if (publicKeyFile.exists()) {
+            val publicKeyBytes = if (publicKeyFile?.exists() == true) {
                 readAdbPublicKey(publicKeyFile)
             } else {
                 ByteArray(0)


### PR DESCRIPTION
It appears that `adbkey.pub` became optional at some point and is no longer generated by platform tools: https://github.com/home-assistant/core/pull/22378

A simple way to verify it is to remove `adbkey.pub` and run `touch ~/.android/adbkey.pub` to replace it with an empty file