### PR TITLE
docs: update instructions to build the project

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,30 @@
+# Contributing Guide 
+
+## Development 
+
+### Pre-requisites 
+
+This project is made in Kotlin, and build with Gradle, thus to build `dadb` from source you'll need 
+
+- JDK (1.8, 11 or 14) setup on your machine
+- Gradle 7.2 (optional; this project can use gradle wrapper automatically too) 
+
+### Building 
+
+```shell
+$ ./gradlew assemble # using the gradle wrapper script 
+```
+or
+```shell
+$ gradle assemble # using your local gradle distribution
+```
+
+### Running Tests 
+
+You can run all tests using 
+
+```shell 
+$ ./gradlew check
+```
+
+> NOTE: Do remember that the unit tests need either an ADB-enabled device or emulator connected to your machine

--- a/README.md
+++ b/README.md
@@ -103,7 +103,6 @@ val adbKeyPair = AdbKeyPair.read(privateKeyFile, publicKeyFile)
 Dadb.create("localhost", 5555, adbKeyPair)
 ```
 
-
 # License
 
 ```

--- a/README.md
+++ b/README.md
@@ -103,35 +103,6 @@ val adbKeyPair = AdbKeyPair.read(privateKeyFile, publicKeyFile)
 Dadb.create("localhost", 5555, adbKeyPair)
 ```
 
-## Development 
-
-### Pre-requisites 
-
-This project is made in Kotlin, and build with Gradle, thus to build `dadb` from source you'll need 
-
-- JDK (1.8, 11 or 14) setup on your machine
-- Gradle 7.2 (optional; this project can use gradle wrapper automatically too) 
-
-### Building 
-
-```shell
-$ ./gradlew assemble # using the gradle wrapper script 
-```
-or
-```shell
-$ gradle assemble # using your local gradle distribution
-```
-
-### Running Tests 
-
-You can run all tests using 
-
-```shell 
-$ ./gradlew check
-```
-
-> NOTE: Do remember that the unit tests need either an ADB-enabled device or emulator connected to your machine
-
 
 # License
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,36 @@ val adbKeyPair = AdbKeyPair.read(privateKeyFile, publicKeyFile)
 Dadb.create("localhost", 5555, adbKeyPair)
 ```
 
+## Development 
+
+### Pre-requisites 
+
+This project is made in Kotlin, and build with Gradle, thus to build `dadb` from source you'll need 
+
+- JDK (1.8, 11 or 14) setup on your machine
+- Gradle 7.2 (optional; this project can use gradle wrapper automatically too) 
+
+### Building 
+
+```shell
+$ ./gradlew assemble # using the gradle wrapper script 
+```
+or
+```shell
+$ gradle assemble # using your local gradle distribution
+```
+
+### Running Tests 
+
+You can run all tests using 
+
+```shell 
+$ ./gradlew check
+```
+
+> NOTE: Do remember that the unit tests need either an ADB-enabled device or emulator connected to your machine
+
+
 # License
 
 ```

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,6 +19,10 @@ plugins {
 }
 
 allprojects {
+    tasks.withType(JavaCompile::class.java) {
+        sourceCompatibility = "1.8"
+        targetCompatibility = "1.8"
+    }
     tasks.withType(KotlinCompile::class.java) {
         kotlinOptions {
             jvmTarget = "1.8"


### PR DESCRIPTION
also updates `compileJava` tasks with targetCompatibility of 1.8 we do not have any `compileJava` today, but tomorrow even if we add any annotation-based libraries, a `compileJava` step will get added, and kotlin and java both should specify the same JVM target

Signed-off-by: Arnav Gupta <championswimmer@gmail.com>