### PR TITLE
Allow setting connect and socket timeouts when creating Dadb object

### DIFF
--- a/dadb/src/main/kotlin/dadb/Dadb.kt
+++ b/dadb/src/main/kotlin/dadb/Dadb.kt
@@ -230,7 +230,7 @@ interface Dadb : AutoCloseable {
 
         @JvmStatic
         @JvmOverloads
-        fun create(host: String, port: Int, keyPair: AdbKeyPair? = AdbKeyPair.readDefault()): Dadb = DadbImpl(host, port, keyPair)
+        fun create(host: String, port: Int, keyPair: AdbKeyPair? = AdbKeyPair.readDefault(), connectTimeout: Int = 0, socketTimeout: Int = 0): Dadb = DadbImpl(host, port, keyPair, connectTimeout, socketTimeout)
 
         @JvmStatic
         @JvmOverloads

--- a/dadb/src/main/kotlin/dadb/DadbImpl.kt
+++ b/dadb/src/main/kotlin/dadb/DadbImpl.kt
@@ -18,13 +18,35 @@
 package dadb
 
 import org.jetbrains.annotations.TestOnly
+import java.net.InetSocketAddress
 import java.net.Socket
+import kotlin.jvm.Throws
 
-internal class DadbImpl(
+
+internal class DadbImpl @Throws(IllegalArgumentException::class) constructor(
         private val host: String,
         private val port: Int,
-        private val keyPair: AdbKeyPair? = null
+        private val keyPair: AdbKeyPair? = null,
+        private val connectTimeout: Int = 0,
+        private val socketTimeout: Int = 0
 ) : Dadb {
+
+    init {
+
+        if (port < 0) {
+            throw IllegalArgumentException("port must be >= 0")
+        }
+
+        if (connectTimeout < 0) {
+            throw IllegalArgumentException("connectTimeout must be >= 0")
+        }
+
+        if (socketTimeout < 0) {
+            throw IllegalArgumentException("socketTimeout must be >= 0")
+        }
+
+    }
+
 
     private var connection: Pair<AdbConnection, Socket>? = null
 
@@ -55,7 +77,10 @@ internal class DadbImpl(
     }
 
     private fun newConnection(): Pair<AdbConnection, Socket> {
-        val socket = Socket(host, port)
+        val socketAddress = InetSocketAddress(host, port)
+        val socket = Socket()
+        socket.soTimeout = socketTimeout
+        socket.connect(socketAddress, connectTimeout)
         val adbConnection = AdbConnection.connect(socket, keyPair)
         return adbConnection to socket
     }

--- a/dadb/src/test/kotlin/dadb/DadbTestImpl.kt
+++ b/dadb/src/test/kotlin/dadb/DadbTestImpl.kt
@@ -1,6 +1,9 @@
 package dadb
 
+import org.junit.jupiter.api.Test
 import java.net.Socket
+import kotlin.test.assertFails
+import kotlin.test.assertNotNull
 
 internal class DadbTestImpl : DadbTest() {
 
@@ -22,4 +25,39 @@ internal class DadbTestImpl : DadbTest() {
 
         override fun close() = connection.close()
     }
+
+    @Test
+    fun validDefaultConstructorValues() {
+        val dadb = Dadb.create("localhost", 5555)
+        assertNotNull(dadb, "Unable to create Dadb object with default constructor values")
+    }
+
+
+    @Test
+    fun validConstructorValues() {
+        val dadb = Dadb.create("localhost", 5555, connectTimeout = 1000, socketTimeout = 10000)
+        assertNotNull(dadb, "Unable to create Dadb object with valid constructor values")
+    }
+
+    @Test
+    fun invalidPortConstructorValue() {
+        assertFails("Invalid port value was not validated") {
+            Dadb.create("localhost", -1, connectTimeout = 0, socketTimeout = 0)
+        }
+    }
+
+    @Test
+    fun invalidconnectTimeoutConstructorValue() {
+        assertFails("Invalid connectTimeout value was not validated") {
+            Dadb.create("localhost", 5555, connectTimeout = -1, socketTimeout = 0)
+        }
+    }
+
+    @Test
+    fun invalidSocketTimeoutConstructorValue() {
+        assertFails("Invalid socketTimeout value was not validated") {
+            Dadb.create("localhost", 5555, connectTimeout = 0, socketTimeout = -1)
+        }
+    }
+
 }


### PR DESCRIPTION
Would be nice to allow setting connect and socket time-outs to avoid any app hanging for long when a device goes offline / emulator is stopped or for probing.