### PR TITLE
feat: implement v1 shell protocol for Android API < 24

### DIFF
--- a/dadb/build.gradle.kts
+++ b/dadb/build.gradle.kts
@@ -41,23 +41,23 @@ tasks.nativeTestCompile {
     dependsOn(tasks.extractGraalTooling)
 }
 
-graalvmNative {
-    binaries {
-        all {
-            buildArgs.add("-H:+EnableAllSecurityServices")
-            javaLauncher.set(provider {
-                val output = tasks.extractGraalTooling.get().outputs.files.singleFile
-                val javaHome = if (OperatingSystem.current().isMacOsX) output.resolve("Contents/Home") else output
-                val metadata = metadataDetector.getMetadata(javaHome)
-                if (!metadata.isValidInstallation) {
-                    throw RuntimeException(metadata.errorMessage)
-                }
-                val spec = objects.newInstance(DefaultToolchainSpec::class.java).apply {
-                    languageVersion.set(JavaLanguageVersion.of(java.targetCompatibility.majorVersion))
-                }
-                val javaToolchain = toolchainFactory.newInstance(javaHome, JavaToolchainInput(spec))
-                javaToolchain.get().javaLauncher
-            })
-        }
-    }
-}
+// graalvmNative {
+//     binaries {
+//         all {
+//             buildArgs.add("-H:+EnableAllSecurityServices")
+//             javaLauncher.set(provider {
+//                 val output = tasks.extractGraalTooling.get().outputs.files.singleFile
+//                 val javaHome = if (OperatingSystem.current().isMacOsX) output.resolve("Contents/Home") else output
+//                 val metadata = metadataDetector.getMetadata(javaHome)
+//                 if (!metadata.isValidInstallation) {
+//                     throw RuntimeException(metadata.errorMessage)
+//                 }
+//                 val spec = objects.newInstance(DefaultToolchainSpec::class.java).apply {
+//                     languageVersion.set(JavaLanguageVersion.of(java.targetCompatibility.majorVersion))
+//                 }
+//                 val javaToolchain = toolchainFactory.newInstance(javaHome, JavaToolchainInput(spec))
+//                 javaToolchain.get().javaLauncher
+//             })
+//         }
+//     }
+// }

--- a/dadb/src/main/kotlin/dadb/AdbConnection.kt
+++ b/dadb/src/main/kotlin/dadb/AdbConnection.kt
@@ -28,12 +28,12 @@ import java.net.Socket
 import java.util.*
 
 internal class AdbConnection internal constructor(
-        adbReader: AdbReader,
-        private val adbWriter: AdbWriter,
-        private val closeable: Closeable?,
-        private val supportedFeatures: Set<String>,
-        private val version: Int,
-        private val maxPayloadSize: Int
+    adbReader: AdbReader,
+    private val adbWriter: AdbWriter,
+    private val closeable: Closeable?,
+    private val supportedFeatures: Set<String>,
+    private val version: Int,
+    private val maxPayloadSize: Int
 ) : AutoCloseable {
 
     private val random = Random()
@@ -127,11 +127,12 @@ internal class AdbConnection internal constructor(
         // ie: "device::ro.product.name=sdk_gphone_x86;ro.product.model=Android SDK built for x86;ro.product.device=generic_x86;features=fixed_push_symlink_timestamp,apex,fixed_push_mkdir,stat_v2,abb_exec,cmd,abb,shell_v2"
         private fun parseConnectionString(connectionString: String): ConnectionString {
             val keyValues = connectionString.substringAfter("device::")
-                    .split(";")
-                    .map { it.split("=") }
-                    .mapNotNull { if (it.size != 2) null else it[0] to it[1] }
-                    .toMap()
-            if ("features" !in keyValues) throw IOException("Failed to parse features from connection string: $connectionString")
+                .split(";")
+                .map { it.split("=") }
+                .mapNotNull { if (it.size != 2) null else it[0] to it[1] }
+                .toMap()
+            if ("features" !in keyValues)
+                return ConnectionString(emptySet())
             val features = keyValues.getValue("features").split(",").toSet()
             return ConnectionString(features)
         }

--- a/dadb/src/main/kotlin/dadb/DadbImpl.kt
+++ b/dadb/src/main/kotlin/dadb/DadbImpl.kt
@@ -24,12 +24,15 @@ import kotlin.jvm.Throws
 
 
 internal class DadbImpl @Throws(IllegalArgumentException::class) constructor(
-        private val host: String,
-        private val port: Int,
-        private val keyPair: AdbKeyPair? = null,
+    private val host: String,
+    private val port: Int,
+    private val keyPair: AdbKeyPair? = null,
         private val connectTimeout: Int = 0,
         private val socketTimeout: Int = 0
 ) : Dadb {
+
+    private val deviceApiLevel: Int = openShellV1("getprop ro.build.version.sdk").use { it.readAll().trim().toIntOrNull() }
+        ?: error("failed to read device's API level")
 
     init {
 
@@ -54,6 +57,10 @@ internal class DadbImpl @Throws(IllegalArgumentException::class) constructor(
 
     override fun supportsFeature(feature: String): Boolean {
         return connection().supportsFeature(feature)
+    }
+
+    override fun getDeviceApiLevel(): Int {
+        return deviceApiLevel
     }
 
     override fun close() {

--- a/dadb/src/main/kotlin/dadb/adbserver/AdbServer.kt
+++ b/dadb/src/main/kotlin/dadb/adbserver/AdbServer.kt
@@ -123,12 +123,15 @@ private class AdbServerDadb constructor(
 ) : Dadb {
 
     private val supportedFeatures: Set<String>
+    private val deviceApiLevel: Int
 
     init {
         supportedFeatures = open("host:features").use {
             val features = AdbServer.readString(DataInputStream(it.source.inputStream()))
             features.split(",").toSet()
         }
+        // ALWAYS do this with protocol 1, otherwise we will end up in endless recursion
+        deviceApiLevel = openShellV1("getprop ro.build.version.sdk").use { it.readAll().trim().toInt() }
     }
 
     override fun open(destination: String): AdbStream {
@@ -148,6 +151,10 @@ private class AdbServerDadb constructor(
 
     override fun supportsFeature(feature: String): Boolean {
         return feature in supportedFeatures
+    }
+
+    override fun getDeviceApiLevel(): Int {
+        return this.deviceApiLevel
     }
 
     override fun close() {}

--- a/dadb/src/test/kotlin/dadb/AdbServerTest.kt
+++ b/dadb/src/test/kotlin/dadb/AdbServerTest.kt
@@ -16,7 +16,7 @@ internal class AdbServerTest : DadbTest() {
         }
     }
 
-    override fun localEmulator(body: (dadb: Dadb) -> Unit) {
-        AdbServer.createDadb("localhost", 5037).use(body)
+    override fun <T> localEmulator(body: (dadb: Dadb) -> T): T {
+        return AdbServer.createDadb("localhost", 5037).use(body)
     }
 }


### PR DESCRIPTION
This PR implements support for the adb v1 shell protocol.
This allows dadb (and maestro) to work on API < 24.

I had issues with the graalvm gradle stuff not compiling, so i commented it out for now.
The changes should also be backwards compatible