### PR TITLE
feat/proposal: Additional method to install an APK from Source 

### DIFF
--- a/dadb/src/test/kotlin/dadb/DadbTest.kt
+++ b/dadb/src/test/kotlin/dadb/DadbTest.kt
@@ -24,6 +24,8 @@ import okio.source
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
 import java.io.ByteArrayInputStream
+import java.io.FileInputStream
+import java.io.FileOutputStream
 import java.net.Socket
 import java.nio.charset.StandardCharsets
 import java.util.*
@@ -186,6 +188,16 @@ internal abstract class DadbTest : BaseConcurrencyTest() {
     fun install() {
         localEmulator { dadb ->
             dadb.install(TestApk.FILE)
+            val response = dadb.shell("pm list packages ${TestApk.PACKAGE_NAME}")
+            assertShellResponse(response, 0, "package:${TestApk.PACKAGE_NAME}\n")
+        }
+    }
+
+    @Test
+    fun installStream() {
+        localEmulator { dadb ->
+            val inputStream = FileInputStream(TestApk.FILE).source()
+            dadb.install(inputStream, TestApk.FILE.length())
             val response = dadb.shell("pm list packages ${TestApk.PACKAGE_NAME}")
             assertShellResponse(response, 0, "package:${TestApk.PACKAGE_NAME}\n")
         }


### PR DESCRIPTION
## Context
The current install method of the Dadb class only receives a File, which is fine for dadb given that it reads and sends it over to the `adb shell cmd package` as an Stream.

However, there could be a case from clients of Dadb that the File is not needed, either the contents of the file is already in memory or an inputstream is already in place, therefore if Dadb can accept a source of bytes it will be more efficient.

## Proposal
This PR adds a new installation method that receives a Source, this will allow a client to decide which one to use, given their use case. 
This PR also reduces duplication by merging the current install method with the new one.

If the device doesn't support "cmd", we would create a new temporary file to store the source before installing with `pm`