### PR TITLE
feat: avoid port collision on Socket creation of the TcpForwarder

### DIFF
--- a/dadb/src/main/kotlin/dadb/Dadb.kt
+++ b/dadb/src/main/kotlin/dadb/Dadb.kt
@@ -19,8 +19,8 @@ package dadb
 
 import dadb.adbserver.AdbServer
 import dadb.forwarding.TcpForwarder
+import dadb.forwarding.TcpForwardDescriptor
 import java.io.File
-import java.io.InputStream
 import java.nio.file.Files
 import okio.*
 
@@ -240,19 +240,19 @@ interface Dadb : AutoCloseable {
     }
 
     @Throws(InterruptedException::class)
-    fun tcpForward(targetPort: Int, hostPort: Int): AutoCloseable {
+    fun tcpForward(targetPort: Int, hostPort: Int): TcpForwardDescriptor {
         val forwarder = TcpForwarder(this, targetPort, hostPort)
-        forwarder.start()
+        val localPort = forwarder.start()
 
-        return forwarder
+        return TcpForwardDescriptor(forwarder, localPort)
     }
 
     @Throws(InterruptedException::class)
-    fun tcpForward(targetPort: Int): Pair<AutoCloseable, Int> {
+    fun tcpForward(targetPort: Int): TcpForwardDescriptor {
         val forwarder = TcpForwarder(this, targetPort)
         val localPort = forwarder.start()
 
-        return forwarder to localPort
+        return TcpForwardDescriptor(forwarder, localPort)
     }
 
     companion object {

--- a/dadb/src/main/kotlin/dadb/Dadb.kt
+++ b/dadb/src/main/kotlin/dadb/Dadb.kt
@@ -240,11 +240,19 @@ interface Dadb : AutoCloseable {
     }
 
     @Throws(InterruptedException::class)
-    fun tcpForward(hostPort: Int, targetPort: Int): AutoCloseable {
-        val forwarder = TcpForwarder(this, hostPort, targetPort)
+    fun tcpForward(targetPort: Int, hostPort: Int): AutoCloseable {
+        val forwarder = TcpForwarder(this, targetPort, hostPort)
         forwarder.start()
 
         return forwarder
+    }
+
+    @Throws(InterruptedException::class)
+    fun tcpForward(targetPort: Int): Pair<AutoCloseable, Int> {
+        val forwarder = TcpForwarder(this, targetPort)
+        val localPort = forwarder.start()
+
+        return forwarder to localPort
     }
 
     companion object {

--- a/dadb/src/main/kotlin/dadb/forwarding/TcpForwarder.kt
+++ b/dadb/src/main/kotlin/dadb/forwarding/TcpForwarder.kt
@@ -19,8 +19,8 @@ import kotlin.concurrent.thread
 
 internal class TcpForwarder(
     private val dadb: Dadb,
-    private val hostPort: Int,
     private val targetPort: Int,
+    private val hostPort: Int? = null,
 ) : AutoCloseable {
 
     private var state: State = State.STOPPED
@@ -28,7 +28,7 @@ internal class TcpForwarder(
     private var server: ServerSocket? = null
     private var clientExecutor: ExecutorService? = null
 
-    fun start() {
+    fun start(): Int {
         check(state == State.STOPPED) { "Forwarder is already started at port $hostPort" }
 
         moveToState(State.STARTING)
@@ -49,10 +49,12 @@ internal class TcpForwarder(
         waitFor(10, 5000) {
             state == State.STARTED
         }
+
+        return server!!.localPort
     }
 
     private fun handleForwarding() {
-        val serverRef = ServerSocket(hostPort)
+        val serverRef = ServerSocket(hostPort ?: 0)
         server = serverRef
 
         moveToState(State.STARTED)

--- a/dadb/src/main/kotlin/dadb/forwarding/TcpForwarder.kt
+++ b/dadb/src/main/kotlin/dadb/forwarding/TcpForwarder.kt
@@ -17,6 +17,12 @@ import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
 import kotlin.concurrent.thread
 
+data class TcpForwardDescriptor(private val resource: AutoCloseable, val localPort: Int): AutoCloseable {
+    override fun close() {
+        resource.close()
+    }
+}
+
 internal class TcpForwarder(
     private val dadb: Dadb,
     private val targetPort: Int,


### PR DESCRIPTION
When creating a ServerSocket we can pass the argument 0 to allow the ServerSocket itself to allocate a free local port. Doing this we reliably avoid port collision errors, as there will be no concurrency errors derived by receiving the host port in the first place.

This PR makes hostPort of the TcpForwarder optional and returns what was the actual allocated port to the client. This was done through a new API on dadb also called tcpForward but without the hostPort argument.