### PR TITLE
Fixed the problem that packet id: "FAIL" was returned when UTF8 characters appeared in the "path" parameter of the "push" method.

### DIFF
--- a/dadb/src/main/kotlin/dadb/AdbSync.kt
+++ b/dadb/src/main/kotlin/dadb/AdbSync.kt
@@ -45,7 +45,7 @@ class AdbSyncStream(
     @Throws(IOException::class)
     fun send(source: Source, remotePath: String, mode: Int, lastModifiedMs: Long) {
         val remote = "$remotePath,$mode"
-        writePacket(SEND, remote.length)
+        writePacket(SEND, remote.toByteArray().size)
 
         stream.sink.apply {
             writeString(remote, StandardCharsets.UTF_8)

--- a/dadb/src/main/kotlin/dadb/AdbSync.kt
+++ b/dadb/src/main/kotlin/dadb/AdbSync.kt
@@ -72,7 +72,7 @@ class AdbSyncStream(
 
     @Throws(IOException::class)
     fun recv(sink: Sink, remotePath: String) {
-        writePacket(RECV, remotePath.length)
+        writePacket(RECV, remotePath.toByteArray().size)
         stream.sink.apply {
             writeString(remotePath, StandardCharsets.UTF_8)
             flush()


### PR DESCRIPTION
In the period version, "java.io.IOException: Unexpected sync packet id: FAIL" was thrown when UTF8 characters appeared in the path parameter of the push method.
<img width="702" alt="Screenshot 2024-01-22 18 48 16" src="https://github.com/mobile-dev-inc/dadb/assets/41728565/41bda67d-34a0-452c-bc39-bb2d26efca58">
<img width="472" alt="Screenshot 2024-01-22 17 44 20" src="https://github.com/mobile-dev-inc/dadb/assets/41728565/3348579d-3f50-468e-a7a6-571be45095c9">

Because characters other than ASCII do not occupy only one byte in UTF8 encoding, so using the "remote.length" method to calculate the byte length will result in an incorrect length result, resulting in a "FAIL".