### PR TITLE
feat: add timeouts to all socket creation management

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,11 @@ jobs:
       - name: checkout
         uses: actions/checkout@v3
 
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'
+          java-version: '8'
+
       - name: Enable KVM
         run: |
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,13 +24,14 @@ jobs:
           path: |
             ~/.android/avd/*
             ~/.android/adb*
-          key: avd-29
+          key: avd-30
 
       - name: create AVD and generate snapshot for caching
         if: steps.avd-cache.outputs.cache-hit != 'true'
         uses: reactivecircus/android-emulator-runner@v2
         with:
-          api-level: 29
+          api-level: 30
+          arch: arm64-v8a
           force-avd-creation: false
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: false
@@ -39,7 +40,8 @@ jobs:
       - name: run tests
         uses: reactivecircus/android-emulator-runner@v2
         with:
-          api-level: 29
+          api-level: 30
+          arch: arm64-v8a
           force-avd-creation: false
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,11 +8,17 @@ on:
 
 jobs:
   test:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
       - name: checkout
         uses: actions/checkout@v3
+
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
 
       - name: Gradle cache
         uses: gradle/gradle-build-action@v2
@@ -31,7 +37,6 @@ jobs:
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: 30
-          arch: arm64-v8a
           force-avd-creation: false
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: false
@@ -41,7 +46,6 @@ jobs:
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: 30
-          arch: arm64-v8a
           force-avd-creation: false
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: create AVD and generate snapshot for caching
         if: steps.avd-cache.outputs.cache-hit != 'true'
-        uses: reactivecircus/android-emulator-runner@v2.28.0
+        uses: reactivecircus/android-emulator-runner@v2.2.0
         with:
           api-level: 29
           force-avd-creation: false
@@ -58,7 +58,7 @@ jobs:
           script: echo "Generated AVD snapshot for caching."
 
       - name: run tests
-        uses: reactivecircus/android-emulator-runner@v2.28.0
+        uses: reactivecircus/android-emulator-runner@v2.2.0
         with:
           api-level: 29
           force-avd-creation: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     timeout-minutes: 15
     steps:
       - name: checkout
@@ -23,12 +23,6 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: '8'
-
-      - name: Enable KVM
-        run: |
-          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
-          sudo udevadm control --reload-rules
-          sudo udevadm trigger --name-match=kvm
 
       - name: Gradle cache
         uses: gradle/gradle-build-action@v2
@@ -53,6 +47,7 @@ jobs:
         with:
           api-level: 29
           force-avd-creation: false
+          arch: arm64-v8
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: false
           script: echo "Generated AVD snapshot for caching."
@@ -61,6 +56,7 @@ jobs:
         uses: reactivecircus/android-emulator-runner@v2.2.0
         with:
           api-level: 29
+          arch: arm64-v8
           force-avd-creation: false
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,11 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v3
+      
+      - name: Home
+        run: |
+          echo $JAVA_HOME
+          echo $PATH
 
       - uses: actions/setup-java@v4
         with:
@@ -36,6 +41,11 @@ jobs:
             ~/.android/avd/*
             ~/.android/adb*
           key: avd-29
+
+      - name: Home
+        run: |
+          echo $JAVA_HOME
+          echo $PATH
 
       - name: create AVD and generate snapshot for caching
         if: steps.avd-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: create AVD and generate snapshot for caching
         if: steps.avd-cache.outputs.cache-hit != 'true'
-        uses: reactivecircus/android-emulator-runner@v2
+        uses: reactivecircus/android-emulator-runner@v2.32.0
         with:
           api-level: 29
           force-avd-creation: false
@@ -58,7 +58,7 @@ jobs:
           script: echo "Generated AVD snapshot for caching."
 
       - name: run tests
-        uses: reactivecircus/android-emulator-runner@v2
+        uses: reactivecircus/android-emulator-runner@v2.32.0
         with:
           api-level: 29
           force-avd-creation: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: create AVD and generate snapshot for caching
         if: steps.avd-cache.outputs.cache-hit != 'true'
-        uses: reactivecircus/android-emulator-runner@v2.32.0
+        uses: reactivecircus/android-emulator-runner@v2.28.0
         with:
           api-level: 29
           force-avd-creation: false
@@ -58,7 +58,7 @@ jobs:
           script: echo "Generated AVD snapshot for caching."
 
       - name: run tests
-        uses: reactivecircus/android-emulator-runner@v2.32.0
+        uses: reactivecircus/android-emulator-runner@v2.28.0
         with:
           api-level: 29
           force-avd-creation: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,22 +8,12 @@ on:
 
 jobs:
   test:
-    runs-on: macos-latest
+    runs-on: macos-13
     timeout-minutes: 15
     steps:
       - name: checkout
         uses: actions/checkout@v3
       
-      - name: Home
-        run: |
-          echo $JAVA_HOME
-          echo $PATH
-
-      - uses: actions/setup-java@v4
-        with:
-          distribution: 'zulu'
-          java-version: '8'
-
       - name: Gradle cache
         uses: gradle/gradle-build-action@v2
 
@@ -47,7 +37,6 @@ jobs:
         with:
           api-level: 29
           force-avd-creation: false
-          arch: arm64-v8
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: false
           script: echo "Generated AVD snapshot for caching."
@@ -56,7 +45,6 @@ jobs:
         uses: reactivecircus/android-emulator-runner@v2.2.0
         with:
           api-level: 29
-          arch: arm64-v8
           force-avd-creation: false
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,13 +30,13 @@ jobs:
           path: |
             ~/.android/avd/*
             ~/.android/adb*
-          key: avd-30
+          key: avd-29
 
       - name: create AVD and generate snapshot for caching
         if: steps.avd-cache.outputs.cache-hit != 'true'
         uses: reactivecircus/android-emulator-runner@v2
         with:
-          api-level: 30
+          api-level: 29
           force-avd-creation: false
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: false
@@ -45,7 +45,7 @@ jobs:
       - name: run tests
         uses: reactivecircus/android-emulator-runner@v2
         with:
-          api-level: 30
+          api-level: 29
           force-avd-creation: false
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,28 +12,10 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: checkout
-        uses: actions/checkout@v3
-        
-      - name: Home
-        run: echo $JAVA_HOME
-      
-      - uses: actions/setup-java@v4
-        with:
-          distribution: 'zulu' # See 'Supported distributions' for available options
-          java-version: '8'
-        
+        uses: actions/checkout@v3        
       
       - name: Gradle cache
         uses: gradle/gradle-build-action@v2
-
-      - name: AVD cache
-        uses: actions/cache@v2
-        id: avd-cache
-        with:
-          path: |
-            ~/.android/avd/*
-            ~/.android/adb*
-          key: avd-29
 
       - name: create AVD and generate snapshot for caching
         if: steps.avd-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,11 +8,20 @@ on:
 
 jobs:
   test:
-    runs-on: macos-13
+    runs-on: macos-12
     timeout-minutes: 15
     steps:
       - name: checkout
         uses: actions/checkout@v3
+        
+      - name: Home
+        run: echo $JAVA_HOME
+      
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu' # See 'Supported distributions' for available options
+          java-version: '8'
+        
       
       - name: Gradle cache
         uses: gradle/gradle-build-action@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,14 +26,9 @@ jobs:
             ~/.android/adb*
           key: avd-29
 
-      - name: Home
-        run: |
-          echo $JAVA_HOME
-          echo $PATH
-
       - name: create AVD and generate snapshot for caching
         if: steps.avd-cache.outputs.cache-hit != 'true'
-        uses: reactivecircus/android-emulator-runner@v2.2.0
+        uses: reactivecircus/android-emulator-runner@v2.29.0
         with:
           api-level: 29
           force-avd-creation: false
@@ -42,7 +37,7 @@ jobs:
           script: echo "Generated AVD snapshot for caching."
 
       - name: run tests
-        uses: reactivecircus/android-emulator-runner@v2.2.0
+        uses: reactivecircus/android-emulator-runner@v2.29.0
         with:
           api-level: 29
           force-avd-creation: false

--- a/dadb/src/main/kotlin/dadb/Dadb.kt
+++ b/dadb/src/main/kotlin/dadb/Dadb.kt
@@ -240,7 +240,7 @@ interface Dadb : AutoCloseable {
     }
 
     @Throws(InterruptedException::class)
-    fun tcpForward(targetPort: Int, hostPort: Int): TcpForwardDescriptor {
+    fun tcpForward(hostPort: Int, targetPort: Int): TcpForwardDescriptor {
         val forwarder = TcpForwarder(this, targetPort, hostPort)
         val localPort = forwarder.start()
 
@@ -266,18 +266,18 @@ interface Dadb : AutoCloseable {
 
         @JvmStatic
         @JvmOverloads
-        fun discover(host: String = "localhost", keyPair: AdbKeyPair? = AdbKeyPair.readDefault()): Dadb? {
-            return list(host, keyPair).firstOrNull()
+        fun discover(host: String = "localhost", keyPair: AdbKeyPair? = AdbKeyPair.readDefault(), connectTimeout: Int = 0, socketTimeout: Int = 0): Dadb? {
+            return list(host, keyPair, connectTimeout, socketTimeout).firstOrNull()
         }
 
         @JvmStatic
         @JvmOverloads
-        fun list(host: String = "localhost", keyPair: AdbKeyPair? = AdbKeyPair.readDefault()): List<Dadb> {
+        fun list(host: String = "localhost", keyPair: AdbKeyPair? = AdbKeyPair.readDefault(), connectTimeout: Int = 0, socketTimeout: Int = 0): List<Dadb> {
             val dadbs = AdbServer.listDadbs(adbServerHost = host)
             if (dadbs.isNotEmpty()) return dadbs
 
             return (MIN_EMULATOR_PORT .. MAX_EMULATOR_PORT).mapNotNull { port ->
-                val dadb = create(host, port, keyPair)
+                val dadb = create(host, port, keyPair, socketTimeout, connectTimeout)
                 val response = try {
                     dadb.shell("echo success").allOutput
                 } catch (ignore : Throwable) {

--- a/dadb/src/test/kotlin/dadb/DadbImplTest.kt
+++ b/dadb/src/test/kotlin/dadb/DadbImplTest.kt
@@ -55,7 +55,7 @@ internal class DadbImplTest {
 
     @Test
     fun discover() {
-        val dadb = Dadb.discover("localhost", AdbKeyPair.readDefault()) ?: fail("Failed to discover emulator")
+        val dadb = Dadb.discover("localhost", AdbKeyPair.readDefault(), 1000, 1000) ?: fail("Failed to discover emulator")
         assertShellResponse(dadb.shell("echo hello"), 0, "hello\n")
     }
 

--- a/dadb/src/test/kotlin/dadb/adbserver/AdbBinaryTest.kt
+++ b/dadb/src/test/kotlin/dadb/adbserver/AdbBinaryTest.kt
@@ -12,7 +12,7 @@ internal class AdbBinaryTest {
         repeat(10) {
             killServer()
             AdbBinary.ensureServerRunning("localhost", 5037)
-            val output = AdbServer.createDadb("localhost", 5037).shell("echo hello").allOutput
+            val output = AdbServer.createDadb("localhost", 5037, connectTimeout = 1000, socketTimeout = 1000).shell("echo hello").allOutput
             assertThat(output).isEqualTo("hello\n")
         }
     }


### PR DESCRIPTION
Allows setting connect and socket timeouts to avoid any app hanging for long when a device goes offline / emulator is stopped or for probing.