### PR TITLE
Allow AdbServer.list() to work with multiple adb devices

### DIFF
--- a/dadb/src/main/kotlin/dadb/adbserver/AdbServer.kt
+++ b/dadb/src/main/kotlin/dadb/adbserver/AdbServer.kt
@@ -50,6 +50,12 @@ object AdbServer {
         connectTimeout: Int = 0,
         socketTimeout: Int = 0
     ): Dadb {
+         if (deviceQuery.startsWith("first:")) {
+            val filter = Regex("^${deviceQuery.removePrefix("first:")}")
+            return listDadbs(adbServerHost, adbServerPort).first {
+                it is AdbServerDadb && it.name.contains(filter)
+            }
+        }
         val name = deviceQuery
             .removePrefix("host:") // Use the device query without the host: prefix
             .removePrefix("transport:") // If it's a serial-number, just show that
@@ -123,7 +129,7 @@ private class AdbServerDadb constructor(
     private val host: String,
     private val port: Int,
     private val deviceQuery: String,
-    private val name: String,
+    val name: String,
     private val connectTimeout: Int = 0,
     private val socketTimeout: Int = 0,
 ) : Dadb {

--- a/dadb/src/main/kotlin/dadb/adbserver/AdbServer.kt
+++ b/dadb/src/main/kotlin/dadb/adbserver/AdbServer.kt
@@ -131,7 +131,7 @@ private class AdbServerDadb constructor(
     private val supportedFeatures: Set<String>
 
     init {
-        supportedFeatures = open("host:features").use {
+        supportedFeatures = open("host-serial:$name:features").use {
             val features = AdbServer.readString(DataInputStream(it.source.inputStream()))
             features.split(",").toSet()
         }

--- a/dadb/src/main/kotlin/dadb/adbserver/AdbServer.kt
+++ b/dadb/src/main/kotlin/dadb/adbserver/AdbServer.kt
@@ -51,7 +51,7 @@ object AdbServer {
         socketTimeout: Int = 0
     ): Dadb {
          if (deviceQuery.startsWith("first:")) {
-            val filter = Regex("^${deviceQuery.removePrefix("first:")}")
+            val filter = Regex(deviceQuery.removePrefix("first:"))
             return listDadbs(adbServerHost, adbServerPort).first {
                 it is AdbServerDadb && it.name.contains(filter)
             }

--- a/dadb/src/test/kotlin/dadb/AdbServerTest.kt
+++ b/dadb/src/test/kotlin/dadb/AdbServerTest.kt
@@ -17,6 +17,6 @@ internal class AdbServerTest : DadbTest() {
     }
 
     override fun localEmulator(body: (dadb: Dadb) -> Unit) {
-        AdbServer.createDadb("localhost", 5037).use(body)
+        AdbServer.createDadb("localhost", 5037, "first:").use(body)
     }
 }

--- a/dadb/src/test/kotlin/dadb/adbserver/AdbBinaryTest.kt
+++ b/dadb/src/test/kotlin/dadb/adbserver/AdbBinaryTest.kt
@@ -12,7 +12,7 @@ internal class AdbBinaryTest {
         repeat(10) {
             killServer()
             AdbBinary.ensureServerRunning("localhost", 5037)
-            val output = AdbServer.createDadb("localhost", 5037, connectTimeout = 1000, socketTimeout = 1000).shell("echo hello").allOutput
+            val output = AdbServer.createDadb("localhost", 5037, deviceQuery = "first:", connectTimeout = 1000, socketTimeout = 1000).shell("echo hello").allOutput
             assertThat(output).isEqualTo("hello\n")
         }
     }


### PR DESCRIPTION
This allows dadb to work with multiple devices attached to adb, and seems to work for my real test case against the Maestro test framework.

To allow the tests to run while multipl devices are attached, I added a 'first:' deviceQualifier - it can be given a regex to select for and against emulators and remote machines.

Despite my concerns in  https://github.com/mobile-dev-inc/dadb/issues/64#issuecomment-2515315382 I think this is an OK solution: it's vanishingly unlikely the device will reconnect between listing, and most adb users work from -s anyway.