### PR TITLE
Fixing Dadb for Windows

### DIFF
--- a/dadb/src/main/kotlin/dadb/AdbKeyPair.kt
+++ b/dadb/src/main/kotlin/dadb/AdbKeyPair.kt
@@ -70,8 +70,8 @@ class AdbKeyPair(
 
         @JvmStatic
         fun readDefault(): AdbKeyPair {
-            val privateKeyFile = File(System.getenv("HOME"), ".android/adbkey")
-            val publicKeyFile = File(System.getenv("HOME"), ".android/adbkey.pub")
+            val privateKeyFile = File(System.getProperty("user.home"), ".android/adbkey")
+            val publicKeyFile = File(System.getProperty("user.home"), ".android/adbkey.pub")
 
             if (!privateKeyFile.exists()) {
                 generate(privateKeyFile, publicKeyFile)

--- a/dadb/src/main/kotlin/dadb/PKCS8.kt
+++ b/dadb/src/main/kotlin/dadb/PKCS8.kt
@@ -28,7 +28,7 @@ internal object PKCS8 {
     private const val SUFFIX = "-----END PRIVATE KEY-----"
 
     fun parse(bytes: ByteArray): PrivateKey {
-        val string = String(bytes).replace(PREFIX, "").replace(SUFFIX, "").replace("\n", "")
+        val string = String(bytes).replace(PREFIX, "").replace(SUFFIX, "").replace(Regex("\\s+"), "")
         val encoded = Base64.getDecoder().decode(string)
         val keyFactory = KeyFactory.getInstance("RSA")
         val keySpec = PKCS8EncodedKeySpec(encoded)


### PR DESCRIPTION
* Use System.getProperty("user.home") instead of System.getenv("HOME")
* Fix PKCS8.parse on Windows