### PR TITLE
fix: use keepAlive for dadb's socket creation 

### DIFF
--- a/dadb/src/main/kotlin/dadb/Dadb.kt
+++ b/dadb/src/main/kotlin/dadb/Dadb.kt
@@ -20,7 +20,6 @@ package dadb
 import dadb.adbserver.AdbServer
 import dadb.forwarding.TcpForwarder
 import java.io.File
-import java.io.InputStream
 import java.nio.file.Files
 import okio.*
 
@@ -254,22 +253,22 @@ interface Dadb : AutoCloseable {
 
         @JvmStatic
         @JvmOverloads
-        fun create(host: String, port: Int, keyPair: AdbKeyPair? = AdbKeyPair.readDefault(), connectTimeout: Int = 0, socketTimeout: Int = 0): Dadb = DadbImpl(host, port, keyPair, connectTimeout, socketTimeout)
+        fun create(host: String, port: Int, keyPair: AdbKeyPair? = AdbKeyPair.readDefault(), connectTimeout: Int = 0, socketTimeout: Int = 0, keepAlive: Boolean = false): Dadb = DadbImpl(host, port, keyPair, connectTimeout, socketTimeout, keepAlive = keepAlive)
 
         @JvmStatic
         @JvmOverloads
-        fun discover(host: String = "localhost", keyPair: AdbKeyPair? = AdbKeyPair.readDefault(), connectTimeout: Int = 0, socketTimeout: Int = 0): Dadb? {
-            return list(host, keyPair, connectTimeout, socketTimeout).firstOrNull()
+        fun discover(host: String = "localhost", keyPair: AdbKeyPair? = AdbKeyPair.readDefault(), connectTimeout: Int = 0, socketTimeout: Int = 0, keepAlive: Boolean = false): Dadb? {
+            return list(host, keyPair, connectTimeout, socketTimeout, keepAlive).firstOrNull()
         }
 
         @JvmStatic
         @JvmOverloads
-        fun list(host: String = "localhost", keyPair: AdbKeyPair? = AdbKeyPair.readDefault(), connectTimeout: Int = 0, socketTimeout: Int = 0): List<Dadb> {
+        fun list(host: String = "localhost", keyPair: AdbKeyPair? = AdbKeyPair.readDefault(), connectTimeout: Int = 0, socketTimeout: Int = 0, keepAlive: Boolean = false): List<Dadb> {
             val dadbs = AdbServer.listDadbs(adbServerHost = host)
             if (dadbs.isNotEmpty()) return dadbs
 
             return (MIN_EMULATOR_PORT .. MAX_EMULATOR_PORT).mapNotNull { port ->
-                val dadb = create(host, port, keyPair, socketTimeout, connectTimeout)
+                val dadb = create(host, port, keyPair, socketTimeout, connectTimeout, keepAlive = keepAlive)
                 val response = try {
                     dadb.shell("echo success").allOutput
                 } catch (ignore : Throwable) {

--- a/dadb/src/main/kotlin/dadb/DadbImpl.kt
+++ b/dadb/src/main/kotlin/dadb/DadbImpl.kt
@@ -28,7 +28,8 @@ internal class DadbImpl @Throws(IllegalArgumentException::class) constructor(
         private val port: Int,
         private val keyPair: AdbKeyPair? = null,
         private val connectTimeout: Int = 0,
-        private val socketTimeout: Int = 0
+        private val socketTimeout: Int = 0,
+        private val keepAlive: Boolean = false,
 ) : Dadb {
 
     init {
@@ -81,6 +82,9 @@ internal class DadbImpl @Throws(IllegalArgumentException::class) constructor(
         val socket = Socket()
         socket.soTimeout = socketTimeout
         socket.connect(socketAddress, connectTimeout)
+        if (keepAlive) {
+            socket.keepAlive = true
+        }
         val adbConnection = AdbConnection.connect(socket, keyPair)
         return adbConnection to socket
     }


### PR DESCRIPTION
This change enables SO_KEEPALIVE on the TCP socket to maintain a persistent connection with the ADB server.

When connections go idle for a while (e.g., no data transfer), the underlying system or network (like GCP VPC) can close them silently. Enabling TCP keep-alive ensures that periodic pings are sent, preventing these idle disconnects.

Reference: https://stackoverflow.com/questions/31810668/java-net-socket-tcp-keep-alive-usage

This helps improve reliability in long-running ADB connections, especially in cloud/CI environments.