### PR TITLE
feat: Extend tcpForward to support more socket domains.

### DIFF
--- a/dadb/src/main/kotlin/dadb/Dadb.kt
+++ b/dadb/src/main/kotlin/dadb/Dadb.kt
@@ -240,6 +240,11 @@ interface Dadb : AutoCloseable {
 
     @Throws(InterruptedException::class)
     fun tcpForward(hostPort: Int, targetPort: Int): AutoCloseable {
+        return tcpForward(hostPort, "tcp:$targetPort")
+    }
+
+    @Throws(InterruptedException::class)
+    fun tcpForward(hostPort: Int, targetPort: String): AutoCloseable {
         val forwarder = TcpForwarder(this, hostPort, targetPort)
         forwarder.start()
 

--- a/dadb/src/main/kotlin/dadb/forwarding/TcpForwarder.kt
+++ b/dadb/src/main/kotlin/dadb/forwarding/TcpForwarder.kt
@@ -20,7 +20,7 @@ import kotlin.concurrent.thread
 internal class TcpForwarder(
     private val dadb: Dadb,
     private val hostPort: Int,
-    private val targetPort: Int,
+    private val targetPort: String,
 ) : AutoCloseable {
 
     private var state: State = State.STOPPED
@@ -61,7 +61,7 @@ internal class TcpForwarder(
             val client = serverRef.accept()
 
             clientExecutor?.execute {
-                val adbStream = dadb.open("tcp:$targetPort")
+                val adbStream = dadb.open(targetPort)
 
                 val readerThread = thread {
                     forward(


### PR DESCRIPTION
Extend tcpForward to support scenarios like:

```bash
adb forward tcp:8000 localabstract:my_abstract
```

Currently it only supports TCP-to-TCP forwarding.