### PR TITLE
Add transport-backed connections and Android USB host support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .gradle
 build
 .idea
+local.properties

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 build
 .idea
 local.properties
+*/.cxx/

--- a/README.md
+++ b/README.md
@@ -6,8 +6,27 @@
 
 <img src="https://user-images.githubusercontent.com/847683/143626125-5872bdd8-180e-48bb-a64f-47b3688a086d.png" width="700px" />
 
-A Kotlin/Java library to connect directly to an Android device without an adb binary or an ADB server.
-The core `dadb` artifact is a JVM library. Platform-specific transports can be added separately.
+A Kotlin/Java library for speaking the ADB protocol directly.
+The core `dadb` artifact is a JVM library. Platform-specific transports can be added separately, and
+using a host-side `adb` binary or `adb server` remains a normal supported option.
+
+Current platform boundary summary:
+
+- STLS/TLS-capable ADB connection is a general ADB capability, not an Android-only protocol
+- Android USB host transport is Android-specific because it depends on Android USB APIs
+- Wireless Debugging pairing (`adb pair`) is currently provided through `dadb-android`
+- if a host-side `adb` binary is available, the `adb server` path it manages remains a normal, supported backend
+
+Practical guidance:
+
+- on desktop and server platforms, using the platform `adb` binary or `adb server` is often the
+  simplest operational choice
+- on Android, relying on an external `adb` binary is usually harder in practice due to packaging,
+  ABI management, process lifecycle, USB host integration, and inconsistent authorization behavior
+  across Android versions and vendor builds
+- `dadb-android` exists mainly to make Android-native ADB integrations more app-controlled and
+  predictable, especially for Wireless Debugging pairing, STLS/TLS transport, and USB host
+  connections
 
 ```kotlin
 dependencies {
@@ -44,12 +63,156 @@ val dadb = Dadb.create(
 )
 ```
 
-This transport is Android-only. Desktop JVM users should use the core `dadb` artifact with direct TCP or `adb server`.
+This transport is Android-only. Desktop JVM users should use the core `dadb` artifact with direct TCP or a host-side `adb` binary / `adb server`.
+
+### Experimental Android Runtime Helper
+
+If your Android app wants a small convenience wrapper around app-private ADB identity storage,
+pairing, and Android-specific transports, `dadb-android` also exposes `AdbRuntime`.
+
+This layer is experimental. Prefer the lower-level transport and pairing APIs directly if you want
+the smallest and most explicit integration surface.
+
+Why this helper exists mostly for Android:
+
+- desktop environments usually already have a manageable `adb` binary / `adb server` workflow
+- Android apps often do not
+- shipping or invoking an external `adb` binary inside an Android app is usually more fragile than
+  using app-controlled transports directly
+- in practice, different Android versions, ROMs, and `adb` binary versions may also differ in how
+  authorization behaves, including repeated authorization prompts or connections that do not behave
+  consistently across devices
+- `dadb-android` is therefore aimed at Android-native integrations where avoiding that external
+  operational dependency is valuable
+
+`AdbRuntime` can own a single runtime directory for:
+
+- `adbkey`
+- `adbkey.pub`
+
+```kotlin
+@OptIn(ExperimentalDadbAndroidApi::class)
+val runtime = AdbRuntime(File(context.filesDir, "adb_keys"))
+val keyPair = runtime.loadOrCreateKeyPair()
+val identity = runtime.readIdentity()
+val publicKey = identity.publicKey
+```
+
+This keeps long-lived ADB identity material in app-private storage instead of scattering it across
+preferences or unrelated app settings.
+
+You can also rotate or replace the local ADB identity through the runtime:
+
+```kotlin
+@OptIn(ExperimentalDadbAndroidApi::class)
+val runtime = AdbRuntime(File(context.filesDir, "adb_keys"))
+
+runtime.regenerateKeyPair()
+runtime.replaceKeyPair(privateKeyPem, publicKeyText)
+```
+
+You can also inspect the current runtime identity:
+
+```kotlin
+@OptIn(ExperimentalDadbAndroidApi::class)
+val runtime = AdbRuntime(File(context.filesDir, "adb_keys"))
+
+val identity = runtime.readIdentity()
+```
+
+### Experimental Android Wireless Debugging TLS
+
+`dadb` core already supports STLS/TLS upgrade when the transport supports it.
+On Android, `dadb-android` provides Android-facing pairing helpers, identity-backed TLS transport,
+and an optional callback that reports the observed server TLS public key pin after a successful
+handshake.
+
+Important boundary:
+
+- the TLS ADB protocol itself is not Android-specific
+- the current pairing/runtime helper layer is Android-specific
+- if you already have a host-side `adb` binary and its `adb server`, you can keep using `AdbServer.createDadb(...)` and do not need the Android runtime helper layer
+
+Typical flow:
+
+1. Pair with the device through `AdbRuntime`.
+2. Connect later through the same runtime using one STLS-capable transport for both plain ADB and Wireless Debugging.
+3. If TLS is established, the runtime reports the observed server identity through `onServerTlsPeerObserved`.
+4. Your app can decide whether to ignore it, persist it, compare it to prior observations, or notify the user.
+
+```kotlin
+@OptIn(ExperimentalDadbAndroidApi::class)
+val runtime = AdbRuntime(File(context.filesDir, "adb_keys"))
+
+runtime.pairWithCode(
+    host = "192.168.0.10",
+    port = 37123,
+    pairingCode = "123456",
+).getOrThrow()
+```
+
+```kotlin
+@OptIn(ExperimentalDadbAndroidApi::class)
+val runtime =
+    AdbRuntime(
+        storageRoot = File(context.filesDir, "adb_keys"),
+        options =
+            AdbRuntimeOptions(
+                onServerTlsPeerObserved = { identity ->
+                    println("observed TLS peer ${identity.target.authority}: ${identity.observedPinSha256Base64}")
+                },
+            ),
+    )
+```
+
+```kotlin
+@OptIn(ExperimentalDadbAndroidApi::class)
+val runtime = AdbRuntime(File(context.filesDir, "adb_keys"))
+val dadb = runtime.connectNetworkDadb(host = "192.168.0.10", port = 37099)
+
+dadb.use {
+    val serial = dadb.shell("getprop ro.serialno").output.trim()
+    println("connected over tls=${dadb.isTlsConnection()}: $serial")
+}
+```
+
+Current trust model note:
+
+- `AdbRuntime` does not persist endpoint or peer trust state by itself
+- `AdbTlsTrustPolicy.TrustAll` accepts the presented TLS certificate and lets the app observe it
+- apps that want TOFU, pin comparison, or identity change notifications should implement that in
+  their own storage layer using `onServerTlsPeerObserved`
+
+### Experimental Android TLS Trust Policy
+
+`AdbRuntime` also accepts an explicit TLS trust policy.
+
+```kotlin
+@OptIn(ExperimentalDadbAndroidApi::class)
+val runtime =
+    AdbRuntime(
+        storageRoot = File(context.filesDir, "adb_keys"),
+        options = AdbRuntimeOptions(
+            tlsTrustPolicy = AdbTlsTrustPolicy.TrustAll,
+        ),
+    )
+```
+
+Available policies:
+
+- `AdbTlsTrustPolicy.TrustAll`
+  - default
+  - accept the presented TLS server certificate without endpoint or pin verification
+  - useful when the app wants to observe the peer identity and make its own trust decision
+- `AdbTlsTrustPolicy.Custom`
+  - provide your own trust manager factory
 
 ### Using adb server
 
-If you already have an `adb server` available, you can connect through it instead of providing a direct transport.
+If you already have a host-side `adb` binary, you can connect through the `adb server` it manages instead of providing a direct transport.
 This is useful on desktop JVM environments where physical devices are already managed by `adb`.
+This path is intentionally still a normal supported option: new TLS, Android USB, or pairing work does not replace or deprecate it.
+For many desktop and server deployments, it is still the easiest path to operate.
 
 ```kotlin
 val dadb = AdbServer.createDadb(
@@ -74,7 +237,7 @@ Use the following API if you want to list all available devices:
 val dadbs = Dadb.list()
 ```
 
-If an `adb server` is available, `Dadb.discover()` and `Dadb.list()` can also return USB-connected physical devices.
+If a host-side `adb` binary / `adb server` is available, `Dadb.discover()` and `Dadb.list()` can also return USB-connected physical devices.
 
 ```kotlin
 // Both of these will include any USB-connected devices if they are available
@@ -84,7 +247,7 @@ val dadbs = Dadb.list()
 
 ### Custom Transport
 
-If your ADB packets do not travel over TCP, Android USB host APIs, or `adb server`, you can still supply your own transport.
+If your ADB packets do not travel over TCP, Android USB host APIs, or a host-side `adb` binary / `adb server`, you can still supply your own transport.
 This is useful for tunnels, in-process bridges, and other bidirectional byte streams.
 
 ```kotlin
@@ -144,6 +307,14 @@ If you need to specify a custom path to your adb key, use the optional `keyPair`
 ```kotlin
 val adbKeyPair = AdbKeyPair.read(privateKeyFile, publicKeyFile)
 Dadb.create("localhost", 5555, adbKeyPair)
+```
+
+On Android, prefer an app-private runtime directory instead of `~/.android`, for example:
+
+```kotlin
+@OptIn(ExperimentalDadbAndroidApi::class)
+val runtime = AdbRuntime(File(context.filesDir, "adb_keys"))
+val adbKeyPair = runtime.loadOrCreateKeyPair()
 ```
 
 # License

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@
 
 <img src="https://user-images.githubusercontent.com/847683/143626125-5872bdd8-180e-48bb-a64f-47b3688a086d.png" width="700px" />
 
-A Kotlin/Java library to connect directly to an Android device without an adb binary or an ADB server
+A Kotlin/Java library to connect directly to an Android device without an adb binary or an ADB server.
+The core `dadb` artifact is a JVM library. Platform-specific transports can be added separately.
 
 ```kotlin
 dependencies {
@@ -14,7 +15,7 @@ dependencies {
 }
 ```
 
-### Example Usage
+### Direct TCP
 
 Connect to `emulator-5554` and install `apkFile`:
 
@@ -25,6 +26,38 @@ Dadb.create("localhost", 5555).use { dadb ->
 ```
 
 *Note: Connect to the odd adb daemon port (5555), not the even emulator console port (5554)*
+
+### Android USB
+
+If you are running on Android and have access to USB host APIs, add the Android transport module:
+
+```kotlin
+implementation("dev.mobile:dadb-android:<version>")
+```
+
+Then create a direct USB transport from `UsbManager` and `UsbDevice`:
+
+```kotlin
+val dadb = Dadb.create(
+    transportFactory = UsbTransportFactory(usbManager, usbDevice, "usb:${usbDevice.deviceName}"),
+    keyPair = AdbKeyPair.readDefault(),
+)
+```
+
+This transport is Android-only. Desktop JVM users should use the core `dadb` artifact with direct TCP or `adb server`.
+
+### Using adb server
+
+If you already have an `adb server` available, you can connect through it instead of providing a direct transport.
+This is useful on desktop JVM environments where physical devices are already managed by `adb`.
+
+```kotlin
+val dadb = AdbServer.createDadb(
+    adbServerHost = "localhost",
+    adbServerPort = 5037,
+    deviceQuery = "host:transport:${serialNumber}"
+)
+```
 
 ### Discover a Device
 
@@ -41,11 +74,7 @@ Use the following API if you want to list all available devices:
 val dadbs = Dadb.list()
 ```
 
-### Connecting to a physical device
-
-*Prerequisite: Connecting to a physical device requires a running adb server. In most cases, this means that you must have the `adb` binary installed on your machine.*
-
-The `Dadb.discover()` and `Dadb.list()` methods now both support USB-connected devices.
+If an `adb server` is available, `Dadb.discover()` and `Dadb.list()` can also return USB-connected physical devices.
 
 ```kotlin
 // Both of these will include any USB-connected devices if they are available
@@ -53,14 +82,23 @@ val dadb = Dadb.discover()
 val dadbs = Dadb.list()
 ```
 
-If you'd like to connect directly to a physical device via its serial number. Use the following API:
+### Custom Transport
+
+If your ADB packets do not travel over TCP, Android USB host APIs, or `adb server`, you can still supply your own transport.
+This is useful for tunnels, in-process bridges, and other bidirectional byte streams.
 
 ```kotlin
-val dadb = AdbServer.createDadb(
-    adbServerHost = "localhost",
-    adbServerPort = 5037,
-    deviceQuery = "host:transport:${serialNumber}"
-)
+val dadb = Dadb.create(
+    description = "my transport",
+    keyPair = AdbKeyPair.readDefault(),
+) {
+    SourceSinkAdbTransport(
+        source = mySource,
+        sink = mySink,
+        description = "my transport",
+        closeable = myTransport,
+    )
+}
 ```
 
 ### Install / Uninstall APK

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,51 +1,46 @@
 import com.adarshr.gradle.testlogger.TestLoggerExtension
 import com.adarshr.gradle.testlogger.theme.ThemeType.STANDARD
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
-buildscript {
-    repositories {
-        mavenCentral()
-    }
-    dependencies {
-        classpath(kotlin("gradle-plugin", "1.9.20"))
-        classpath("com.vanniktech:gradle-maven-publish-plugin:0.33.0")
-    }
-}
-
 plugins {
-    id("com.adarshr.test-logger") version("3.2.0") apply(true)
+    id("com.android.library") version "9.1.0" apply false
+    id("com.adarshr.test-logger") version "4.0.0" apply false
+    id("com.vanniktech.maven.publish") version "0.36.0" apply false
+    kotlin("jvm") version "2.3.20" apply false
 }
 
 allprojects {
-    tasks.withType(JavaCompile::class.java) {
+    pluginManager.apply("com.adarshr.test-logger")
+
+    tasks.withType(JavaCompile::class.java).configureEach {
         sourceCompatibility = JavaVersion.VERSION_17.toString()
         targetCompatibility = JavaVersion.VERSION_17.toString()
     }
-    tasks.withType(KotlinCompile::class.java) {
-        kotlinOptions {
-            jvmTarget = JavaVersion.VERSION_17.toString()
-            freeCompilerArgs += "-Xopt-in=kotlin.ExperimentalUnsignedTypes"
+
+    tasks.withType(KotlinCompile::class.java).configureEach {
+        compilerOptions {
+            jvmTarget.set(JvmTarget.JVM_17)
+            optIn.add("kotlin.ExperimentalUnsignedTypes")
         }
     }
-    tasks.withType(Task::class) {
-        project.apply(plugin = "com.adarshr.test-logger")
-        project.configure<TestLoggerExtension> {
-            theme = STANDARD
-            showExceptions = true
-            showStackTraces = false
-            showFullStackTraces = false
-            showCauses = true
-            slowThreshold = 5000
-            showSummary = true
-            showSimpleNames = false
-            showPassed = true
-            showSkipped = true
-            showFailed = true
-            showOnlySlow = false
-            showStandardStreams = false
-            showPassedStandardStreams = false
-            showSkippedStandardStreams = false
-            showFailedStandardStreams = true
-        }
+
+    configure<TestLoggerExtension> {
+        theme = STANDARD
+        showExceptions = true
+        showStackTraces = false
+        showFullStackTraces = false
+        showCauses = true
+        slowThreshold = 5000
+        showSummary = true
+        showSimpleNames = false
+        showPassed = true
+        showSkipped = true
+        showFailed = true
+        showOnlySlow = false
+        showStandardStreams = false
+        showPassedStandardStreams = false
+        showSkippedStandardStreams = false
+        showFailedStandardStreams = true
     }
 }

--- a/dadb-android/build.gradle.kts
+++ b/dadb-android/build.gradle.kts
@@ -1,0 +1,28 @@
+plugins {
+    id("com.android.library")
+    id("com.vanniktech.maven.publish")
+}
+
+android {
+    namespace = "dadb.android"
+    compileSdk = 36
+
+    defaultConfig {
+        minSdk = 23
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+}
+
+dependencies {
+    api(project(":dadb"))
+
+    testImplementation("junit:junit:4.13.2")
+}
+
+mavenPublishing {
+    publishToMavenCentral(true)
+}

--- a/dadb-android/build.gradle.kts
+++ b/dadb-android/build.gradle.kts
@@ -10,6 +10,7 @@ android {
     defaultConfig {
         minSdk = 23
 
+        @Suppress("UnstableApiUsage")
         externalNativeBuild {
             cmake {
                 cppFlags += "-std=c++17"
@@ -33,7 +34,10 @@ android {
 
     externalNativeBuild {
         cmake {
-            path = file("src/main/cpp/CMakeLists.txt")
+            path =
+                project.layout.projectDirectory
+                    .file("src/main/cpp/CMakeLists.txt")
+                    .asFile
             version = "3.22.1"
         }
     }

--- a/dadb-android/build.gradle.kts
+++ b/dadb-android/build.gradle.kts
@@ -9,18 +9,44 @@ android {
 
     defaultConfig {
         minSdk = 23
+
+        externalNativeBuild {
+            cmake {
+                cppFlags += "-std=c++17"
+                arguments +=
+                    listOf(
+                        "-DANDROID_STL=c++_shared",
+                        "-DANDROID_PLATFORM=android-23",
+                    )
+            }
+        }
+    }
+
+    buildFeatures {
+        prefab = true
     }
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
     }
+
+    externalNativeBuild {
+        cmake {
+            path = file("src/main/cpp/CMakeLists.txt")
+            version = "3.22.1"
+        }
+    }
 }
 
 dependencies {
     api(project(":dadb"))
+    implementation("org.bouncycastle:bcpkix-jdk18on:1.80")
+    implementation("io.github.vvb2060.ndk:boringssl:20250114")
+    implementation("org.conscrypt:conscrypt-android:2.5.2")
 
     testImplementation("junit:junit:4.13.2")
+    testImplementation("org.json:json:20240303")
 }
 
 mavenPublishing {

--- a/dadb-android/build.gradle.kts
+++ b/dadb-android/build.gradle.kts
@@ -41,12 +41,13 @@ android {
 
 dependencies {
     api(project(":dadb"))
-    implementation("org.bouncycastle:bcpkix-jdk18on:1.80")
-    implementation("io.github.vvb2060.ndk:boringssl:20250114")
-    implementation("org.conscrypt:conscrypt-android:2.5.2")
+    implementation("org.bouncycastle:bcpkix-jdk18on:1.83")
+    implementation("io.github.vvb2060.ndk:boringssl:20251124")
+    //noinspection Aligned16KB
+    implementation("org.conscrypt:conscrypt-android:2.5.3")
 
     testImplementation("junit:junit:4.13.2")
-    testImplementation("org.json:json:20240303")
+    testImplementation("org.json:json:20251224")
 }
 
 mavenPublishing {

--- a/dadb-android/gradle.properties
+++ b/dadb-android/gradle.properties
@@ -1,0 +1,4 @@
+POM_NAME=dadb-android
+POM_ARTIFACT_ID=dadb-android
+POM_PACKAGING=aar
+POM_DESCRIPTION=Android USB host transport support for dadb

--- a/dadb-android/src/main/AndroidManifest.xml
+++ b/dadb-android/src/main/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest />

--- a/dadb-android/src/main/cpp/CMakeLists.txt
+++ b/dadb-android/src/main/cpp/CMakeLists.txt
@@ -1,0 +1,24 @@
+cmake_minimum_required(VERSION 3.18.1)
+
+project("dadb_android")
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+find_package(boringssl REQUIRED CONFIG)
+
+add_library(
+    adbpairing
+    SHARED
+    pairing/adb_pairing.cpp
+)
+
+find_library(log-lib log)
+
+target_link_libraries(
+    adbpairing
+    ${log-lib}
+    boringssl::crypto_static
+)

--- a/dadb-android/src/main/cpp/pairing/adb_pairing.cpp
+++ b/dadb-android/src/main/cpp/pairing/adb_pairing.cpp
@@ -1,0 +1,295 @@
+#include <jni.h>
+#include <cstring>
+#include <cstdlib>
+#include <cinttypes>
+#include <openssl/curve25519.h>
+#include <openssl/hkdf.h>
+#include <openssl/evp.h>
+#include "logging.h"
+
+static constexpr spake2_role_t kClientRole = spake2_role_alice;
+static constexpr spake2_role_t kServerRole = spake2_role_bob;
+
+static const uint8_t kClientName[] = "adb pair client";
+static const uint8_t kServerName[] = "adb pair server";
+
+static constexpr size_t kHkdfKeyLength = 16;
+
+struct PairingContextNative {
+    SPAKE2_CTX* spake2_ctx;
+    uint8_t key[SPAKE2_MAX_MSG_SIZE];
+    size_t key_size;
+
+    EVP_AEAD_CTX* aes_ctx;
+    uint64_t dec_sequence;
+    uint64_t enc_sequence;
+};
+
+static jlong PairingContext_Constructor(JNIEnv* env, jclass clazz, jboolean isClient, jbyteArray jPassword) {
+    spake2_role_t spake_role;
+    const uint8_t* my_name;
+    const uint8_t* their_name;
+    size_t my_len;
+    size_t their_len;
+
+    if (isClient) {
+        spake_role = kClientRole;
+        my_name = kClientName;
+        my_len = sizeof(kClientName);
+        their_name = kServerName;
+        their_len = sizeof(kServerName);
+    } else {
+        spake_role = kServerRole;
+        my_name = kServerName;
+        my_len = sizeof(kServerName);
+        their_name = kClientName;
+        their_len = sizeof(kClientName);
+    }
+
+    auto spake2_ctx = SPAKE2_CTX_new(spake_role, my_name, my_len, their_name, their_len);
+    if (spake2_ctx == nullptr) {
+        LOGE("Unable to create a SPAKE2 context.");
+        return 0;
+    }
+
+    auto pswd_size = env->GetArrayLength(jPassword);
+    auto pswd = env->GetByteArrayElements(jPassword, nullptr);
+
+    size_t key_size = 0;
+    uint8_t key[SPAKE2_MAX_MSG_SIZE];
+    int status = SPAKE2_generate_msg(
+        spake2_ctx,
+        key,
+        &key_size,
+        SPAKE2_MAX_MSG_SIZE,
+        reinterpret_cast<uint8_t*>(pswd),
+        pswd_size
+    );
+    if (status != 1 || key_size == 0) {
+        LOGE("Unable to generate the SPAKE2 public key.");
+
+        env->ReleaseByteArrayElements(jPassword, pswd, 0);
+        SPAKE2_CTX_free(spake2_ctx);
+        return 0;
+    }
+    env->ReleaseByteArrayElements(jPassword, pswd, 0);
+
+    auto ctx = reinterpret_cast<PairingContextNative*>(malloc(sizeof(PairingContextNative)));
+    memset(ctx, 0, sizeof(PairingContextNative));
+    ctx->spake2_ctx = spake2_ctx;
+    memcpy(ctx->key, key, SPAKE2_MAX_MSG_SIZE);
+    ctx->key_size = key_size;
+    return reinterpret_cast<jlong>(ctx);
+}
+
+static jbyteArray PairingContext_Msg(JNIEnv* env, jobject obj, jlong ptr) {
+    auto ctx = reinterpret_cast<PairingContextNative*>(ptr);
+    jbyteArray our_msg = env->NewByteArray(static_cast<jsize>(ctx->key_size));
+    env->SetByteArrayRegion(our_msg, 0, static_cast<jsize>(ctx->key_size), reinterpret_cast<jbyte*>(ctx->key));
+    return our_msg;
+}
+
+static jboolean PairingContext_InitCipher(JNIEnv* env, jobject obj, jlong ptr, jbyteArray jTheirMsg) {
+    auto ctx = reinterpret_cast<PairingContextNative*>(ptr);
+    auto spake2_ctx = ctx->spake2_ctx;
+    auto their_msg_size = env->GetArrayLength(jTheirMsg);
+
+    if (their_msg_size > SPAKE2_MAX_MSG_SIZE) {
+        LOGE("their_msg size [%d] greater then max size [%d].", their_msg_size, SPAKE2_MAX_MSG_SIZE);
+        return JNI_FALSE;
+    }
+
+    auto their_msg = env->GetByteArrayElements(jTheirMsg, nullptr);
+
+    size_t key_material_len = 0;
+    uint8_t key_material[SPAKE2_MAX_KEY_SIZE];
+    int status = SPAKE2_process_msg(
+        spake2_ctx,
+        key_material,
+        &key_material_len,
+        sizeof(key_material),
+        reinterpret_cast<uint8_t*>(their_msg),
+        their_msg_size
+    );
+
+    env->ReleaseByteArrayElements(jTheirMsg, their_msg, 0);
+
+    if (status != 1) {
+        LOGE("Unable to process their public key");
+        return JNI_FALSE;
+    }
+
+    uint8_t key[kHkdfKeyLength];
+    uint8_t info[] = "adb pairing_auth aes-128-gcm key";
+
+    status = HKDF(
+        key,
+        sizeof(key),
+        EVP_sha256(),
+        key_material,
+        key_material_len,
+        nullptr,
+        0,
+        info,
+        sizeof(info) - 1
+    );
+    if (status != 1) {
+        LOGE("HKDF");
+        return JNI_FALSE;
+    }
+
+    ctx->aes_ctx = EVP_AEAD_CTX_new(EVP_aead_aes_128_gcm(), key, sizeof(key), EVP_AEAD_DEFAULT_TAG_LENGTH);
+
+    if (!ctx->aes_ctx) {
+        LOGE("EVP_AEAD_CTX_new");
+        return JNI_FALSE;
+    }
+
+    return JNI_TRUE;
+}
+
+static jbyteArray PairingContext_Encrypt(JNIEnv* env, jobject obj, jlong ptr, jbyteArray jIn) {
+    auto ctx = reinterpret_cast<PairingContextNative*>(ptr);
+    auto aes_ctx = ctx->aes_ctx;
+
+    auto in = env->GetByteArrayElements(jIn, nullptr);
+    auto in_size = env->GetArrayLength(jIn);
+
+    auto out_size = static_cast<size_t>(in_size) + EVP_AEAD_max_overhead(EVP_AEAD_CTX_aead(aes_ctx));
+    auto out = reinterpret_cast<uint8_t*>(malloc(out_size));
+    if (!out) {
+        env->ReleaseByteArrayElements(jIn, in, 0);
+        return nullptr;
+    }
+
+    auto nonce_size = EVP_AEAD_nonce_length(EVP_AEAD_CTX_aead(aes_ctx));
+    auto nonce = reinterpret_cast<uint8_t*>(malloc(nonce_size));
+    if (!nonce) {
+        free(out);
+        env->ReleaseByteArrayElements(jIn, in, 0);
+        return nullptr;
+    }
+    memset(nonce, 0, nonce_size);
+    memcpy(nonce, &ctx->enc_sequence, sizeof(ctx->enc_sequence));
+
+    size_t written_sz;
+    int status = EVP_AEAD_CTX_seal(
+        aes_ctx,
+        out,
+        &written_sz,
+        out_size,
+        nonce,
+        nonce_size,
+        reinterpret_cast<uint8_t*>(in),
+        in_size,
+        nullptr,
+        0
+    );
+
+    env->ReleaseByteArrayElements(jIn, in, 0);
+    free(nonce);
+
+    if (!status) {
+        LOGE("Failed to encrypt (in_len=%d, out_cap=%" PRIuPTR ")", in_size, out_size);
+        free(out);
+        return nullptr;
+    }
+    ++ctx->enc_sequence;
+
+    jbyteArray jOut = env->NewByteArray(static_cast<jsize>(written_sz));
+    env->SetByteArrayRegion(jOut, 0, static_cast<jsize>(written_sz), reinterpret_cast<jbyte*>(out));
+    free(out);
+    return jOut;
+}
+
+static jbyteArray PairingContext_Decrypt(JNIEnv* env, jobject obj, jlong ptr, jbyteArray jIn) {
+    auto ctx = reinterpret_cast<PairingContextNative*>(ptr);
+    auto aes_ctx = ctx->aes_ctx;
+
+    auto in = env->GetByteArrayElements(jIn, nullptr);
+    auto in_size = env->GetArrayLength(jIn);
+
+    auto out_size = static_cast<size_t>(in_size);
+    auto out = reinterpret_cast<uint8_t*>(malloc(out_size));
+    if (!out) {
+        env->ReleaseByteArrayElements(jIn, in, 0);
+        return nullptr;
+    }
+
+    auto nonce_size = EVP_AEAD_nonce_length(EVP_AEAD_CTX_aead(aes_ctx));
+    auto nonce = reinterpret_cast<uint8_t*>(malloc(nonce_size));
+    if (!nonce) {
+        free(out);
+        env->ReleaseByteArrayElements(jIn, in, 0);
+        return nullptr;
+    }
+    memset(nonce, 0, nonce_size);
+    memcpy(nonce, &ctx->dec_sequence, sizeof(ctx->dec_sequence));
+
+    size_t written_sz;
+    int status = EVP_AEAD_CTX_open(
+        aes_ctx,
+        out,
+        &written_sz,
+        out_size,
+        nonce,
+        nonce_size,
+        reinterpret_cast<uint8_t*>(in),
+        in_size,
+        nullptr,
+        0
+    );
+
+    env->ReleaseByteArrayElements(jIn, in, 0);
+    free(nonce);
+
+    if (!status) {
+        LOGE("Failed to decrypt (in_len=%d, out_cap=%" PRIuPTR ")", in_size, out_size);
+        free(out);
+        return nullptr;
+    }
+    ++ctx->dec_sequence;
+
+    jbyteArray jOut = env->NewByteArray(static_cast<jsize>(written_sz));
+    env->SetByteArrayRegion(jOut, 0, static_cast<jsize>(written_sz), reinterpret_cast<jbyte*>(out));
+    free(out);
+    return jOut;
+}
+
+static void PairingContext_Destroy(JNIEnv* env, jobject obj, jlong ptr) {
+    auto ctx = reinterpret_cast<PairingContextNative*>(ptr);
+    if (!ctx) return;
+    SPAKE2_CTX_free(ctx->spake2_ctx);
+    if (ctx->aes_ctx) {
+        EVP_AEAD_CTX_free(ctx->aes_ctx);
+    }
+    free(ctx);
+}
+
+JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM* vm, void* reserved) {
+    JNIEnv* env = nullptr;
+
+    if (vm->GetEnv(reinterpret_cast<void**>(&env), JNI_VERSION_1_6) != JNI_OK) {
+        return -1;
+    }
+
+    JNINativeMethod methods[] = {
+        {"nativeConstructor", "(Z[B)J", reinterpret_cast<void*>(PairingContext_Constructor)},
+        {"nativeMsg", "(J)[B", reinterpret_cast<void*>(PairingContext_Msg)},
+        {"nativeInitCipher", "(J[B)Z", reinterpret_cast<void*>(PairingContext_InitCipher)},
+        {"nativeEncrypt", "(J[B)[B", reinterpret_cast<void*>(PairingContext_Encrypt)},
+        {"nativeDecrypt", "(J[B)[B", reinterpret_cast<void*>(PairingContext_Decrypt)},
+        {"nativeDestroy", "(J)V", reinterpret_cast<void*>(PairingContext_Destroy)},
+    };
+
+    jclass clazz = env->FindClass("dadb/android/wireless/PairingContext");
+    if (clazz == nullptr) {
+        return -1;
+    }
+
+    if (env->RegisterNatives(clazz, methods, sizeof(methods) / sizeof(methods[0])) != 0) {
+        return -1;
+    }
+
+    return JNI_VERSION_1_6;
+}

--- a/dadb-android/src/main/cpp/pairing/logging.h
+++ b/dadb-android/src/main/cpp/pairing/logging.h
@@ -1,0 +1,6 @@
+#pragma once
+
+#include <android/log.h>
+
+#define LOG_TAG "adbpairing"
+#define LOGE(...) __android_log_print(ANDROID_LOG_ERROR, LOG_TAG, __VA_ARGS__)

--- a/dadb-android/src/main/kotlin/dadb/android/runtime/AdbRuntime.kt
+++ b/dadb-android/src/main/kotlin/dadb/android/runtime/AdbRuntime.kt
@@ -77,6 +77,7 @@ class AdbRuntime(
         port: Int,
         connectTimeout: Int = 0,
         socketTimeout: Int = 0,
+        features: Set<String> = Dadb.connectFeatures(),
     ): Dadb {
         val keyPair = loadOrCreateKeyPair()
         val target = AdbNetworkEndpoint(host = host, port = port)
@@ -102,6 +103,7 @@ class AdbRuntime(
                     },
                 ),
                 keyPair,
+                features,
             )
 
         try {

--- a/dadb-android/src/main/kotlin/dadb/android/runtime/AdbRuntime.kt
+++ b/dadb-android/src/main/kotlin/dadb/android/runtime/AdbRuntime.kt
@@ -1,0 +1,132 @@
+package dadb.android.runtime
+
+import android.content.Context
+import android.hardware.usb.UsbDevice
+import android.hardware.usb.UsbManager
+import dadb.AdbKeyPair
+import dadb.Dadb
+import dadb.android.storage.AdbIdentityStore
+import dadb.android.tls.AdbTlsCertificatePins
+import dadb.android.tls.TlsAdbTransportFactory
+import dadb.android.usb.UsbTransportFactory
+import dadb.android.wireless.WirelessDebugPairingClient
+import dadb.android.wireless.WirelessDebugPairingRequest
+import dadb.android.wireless.WirelessDebugPairingResult
+import java.io.File
+import java.security.cert.X509Certificate
+
+@ExperimentalDadbAndroidApi
+/**
+ * Experimental Android convenience layer around app-private ADB identity storage, Wireless
+ * Debugging pairing, and Android-specific transport helpers.
+ *
+ * Prefer the lower-level transport and pairing APIs directly if you want a smaller, more explicit
+ * integration surface.
+ */
+class AdbRuntime(
+    storageRoot: File,
+    private val options: AdbRuntimeOptions = AdbRuntimeOptions(),
+) {
+    constructor(
+        context: Context,
+        options: AdbRuntimeOptions = AdbRuntimeOptions(),
+    ) : this(defaultStorageRoot(context), options)
+
+    private val identityStore = AdbIdentityStore(storageRoot)
+
+    fun loadOrCreateKeyPair(): AdbKeyPair = identityStore.loadOrCreate()
+
+    fun regenerateKeyPair(): AdbKeyPair = identityStore.regenerate()
+
+    fun replaceKeyPair(
+        privateKey: String,
+        publicKey: String,
+    ): AdbKeyPair {
+        identityStore.replace(privateKey, publicKey)
+        return identityStore.loadOrCreate()
+    }
+
+    fun readIdentity(): AdbRuntimeIdentity =
+        AdbRuntimeIdentity(
+            privateKey = identityStore.readPrivateKey(),
+            publicKey = identityStore.readPublicKey(),
+        )
+
+    fun pairWithCode(
+        host: String,
+        port: Int,
+        pairingCode: String,
+    ): Result<WirelessDebugPairingResult> {
+        val keyPair = loadOrCreateKeyPair()
+        return WirelessDebugPairingClient(keyPair)
+            .pair(
+                WirelessDebugPairingRequest(
+                    host = host,
+                    port = port,
+                    pairingCode = pairingCode,
+                ),
+            )
+    }
+
+    fun connectNetworkDadb(
+        host: String,
+        port: Int,
+        connectTimeout: Int = 0,
+        socketTimeout: Int = 0,
+    ): Dadb {
+        val keyPair = loadOrCreateKeyPair()
+        val target = AdbNetworkEndpoint(host = host, port = port)
+
+        val dadb =
+            Dadb.create(
+                TlsAdbTransportFactory(
+                    host = host,
+                    port = port,
+                    keyPair = keyPair,
+                    trustManager = options.tlsTrustPolicy.resolveTrustManager(target),
+                    connectTimeout = connectTimeout,
+                    socketTimeout = socketTimeout,
+                    onHandshakeCompleted = { sslSocket ->
+                        val certificate = sslSocket.session.peerCertificates.firstOrNull() as? X509Certificate
+                            ?: return@TlsAdbTransportFactory
+                        options.onServerTlsPeerObserved?.invoke(
+                            AdbTlsPeerIdentity(
+                                target = target,
+                                observedPinSha256Base64 = AdbTlsCertificatePins.publicKeySha256Base64(certificate),
+                            ),
+                        )
+                    },
+                ),
+                keyPair,
+            )
+
+        try {
+            dadb.supportsFeature("shell_v2")
+        } catch (t: Throwable) {
+            runCatching { dadb.close() }
+            throw t
+        }
+
+        return dadb
+    }
+
+    fun createUsbDadb(
+        usbManager: UsbManager,
+        usbDevice: UsbDevice,
+        description: String = usbDevice.deviceName,
+    ): Dadb {
+        val keyPair = loadOrCreateKeyPair()
+        return Dadb.create(
+            UsbTransportFactory(
+                usbManager = usbManager,
+                usbDevice = usbDevice,
+                description = description,
+            ),
+            keyPair,
+        )
+    }
+
+    companion object {
+        fun defaultStorageRoot(context: Context): File = File(context.filesDir, "adb_keys")
+    }
+}

--- a/dadb-android/src/main/kotlin/dadb/android/runtime/AdbRuntime.kt
+++ b/dadb-android/src/main/kotlin/dadb/android/runtime/AdbRuntime.kt
@@ -3,6 +3,7 @@ package dadb.android.runtime
 import android.content.Context
 import android.hardware.usb.UsbDevice
 import android.hardware.usb.UsbManager
+import android.util.Log
 import dadb.AdbKeyPair
 import dadb.Dadb
 import dadb.android.storage.AdbIdentityStore
@@ -15,7 +16,6 @@ import dadb.android.wireless.WirelessDebugPairingResult
 import java.io.File
 import java.security.cert.X509Certificate
 
-@ExperimentalDadbAndroidApi
 /**
  * Experimental Android convenience layer around app-private ADB identity storage, Wireless
  * Debugging pairing, and Android-specific transport helpers.
@@ -23,6 +23,7 @@ import java.security.cert.X509Certificate
  * Prefer the lower-level transport and pairing APIs directly if you want a smaller, more explicit
  * integration surface.
  */
+@ExperimentalDadbAndroidApi
 class AdbRuntime(
     storageRoot: File,
     private val options: AdbRuntimeOptions = AdbRuntimeOptions(),
@@ -92,8 +93,9 @@ class AdbRuntime(
                     connectTimeout = connectTimeout,
                     socketTimeout = socketTimeout,
                     onHandshakeCompleted = { sslSocket ->
-                        val certificate = sslSocket.session.peerCertificates.firstOrNull() as? X509Certificate
-                            ?: return@TlsAdbTransportFactory
+                        val certificate =
+                            sslSocket.session.peerCertificates.firstOrNull() as? X509Certificate
+                                ?: return@TlsAdbTransportFactory
                         options.onServerTlsPeerObserved?.invoke(
                             AdbTlsPeerIdentity(
                                 target = target,
@@ -140,37 +142,112 @@ class AdbRuntime(
         features: Set<String>,
     ): Dadb {
         var lastError: Throwable? = null
+        var activeUsbDevice = usbDevice
 
-        repeat(2) { attempt ->
-            val dadb =
-                Dadb.create(
-                    UsbTransportFactory(
-                        usbManager = usbManager,
-                        usbDevice = usbDevice,
-                        description = description,
-                    ),
-                    keyPair,
-                    features,
-                )
+        repeat(3) { attempt ->
+            Log.d(
+                USB_RUNTIME_TAG,
+                "createUsbDadb start attempt=${attempt + 1} description=$description features=${features.joinToString(
+                    ",",
+                )} " +
+                    "devicePath=${activeUsbDevice.deviceName} vendor=${activeUsbDevice.vendorId} product=${activeUsbDevice.productId} " +
+                    "manufacturer=${activeUsbDevice.manufacturerName ?: "Unknown"} productName=${activeUsbDevice.productName ?: "Unknown"}",
+            )
+            var dadb: Dadb? = null
 
             try {
+                dadb =
+                    Dadb.create(
+                        UsbTransportFactory(
+                            usbManager = usbManager,
+                            usbDevice = activeUsbDevice,
+                            description = description,
+                        ),
+                        keyPair,
+                        features,
+                    )
                 // Warm the USB transport before returning so the caller does not pay the cost
                 // of discovering a stale first handshake/open on its first shell request.
                 dadb.supportsFeature("shell_v2")
+                Log.d(
+                    USB_RUNTIME_TAG,
+                    "createUsbDadb warm-up success attempt=${attempt + 1} description=$description shell_v2=${
+                        dadb.supportsFeature(
+                            "shell_v2",
+                        )
+                    }",
+                )
                 return dadb
             } catch (t: Throwable) {
                 lastError = t
-                runCatching { dadb.close() }
-                if (attempt == 0) {
-                    Thread.sleep(150)
+                Log.w(
+                    USB_RUNTIME_TAG,
+                    "createUsbDadb warm-up failed attempt=${attempt + 1} description=$description error=${t.javaClass.simpleName}: ${t.message}",
+                    t,
+                )
+                runCatching { dadb?.close() }
+                if (attempt < 2) {
+                    val sleepMs = 150L * (attempt + 1)
+                    Log.d(
+                        USB_RUNTIME_TAG,
+                        "createUsbDadb retrying after failure description=$description sleepMs=$sleepMs",
+                    )
+                    Thread.sleep(sleepMs)
+                    val refreshedUsbDevice = refreshUsbReconnectCandidate(usbManager, activeUsbDevice)
+                    if (refreshedUsbDevice !== activeUsbDevice) {
+                        Log.d(
+                            USB_RUNTIME_TAG,
+                            "createUsbDadb switched USB candidate description=$description oldPath=${activeUsbDevice.deviceName} newPath=${refreshedUsbDevice.deviceName}",
+                        )
+                    }
+                    activeUsbDevice = refreshedUsbDevice
                 }
             }
         }
 
+        Log.e(
+            USB_RUNTIME_TAG,
+            "createUsbDadb failed description=$description error=${lastError?.javaClass?.simpleName}: ${lastError?.message}",
+            lastError,
+        )
         throw lastError ?: IllegalStateException("Failed to create USB Dadb: $description")
     }
 
+    private fun refreshUsbReconnectCandidate(
+        usbManager: UsbManager,
+        currentDevice: UsbDevice,
+    ): UsbDevice {
+        val currentSerial =
+            runCatching { currentDevice.serialNumber }
+                .getOrNull()
+                ?.takeIf { it.isNotBlank() }
+        val currentManufacturer = currentDevice.manufacturerName.orEmpty()
+        val currentProductName = currentDevice.productName.orEmpty()
+        val currentVendorId = currentDevice.vendorId
+        val currentProductId = currentDevice.productId
+        val currentInterfaceCount = currentDevice.interfaceCount
+
+        val candidates = usbManager.deviceList.values.toList()
+
+        currentSerial?.let { serial ->
+            candidates
+                .firstOrNull { candidate ->
+                    runCatching { candidate.serialNumber }.getOrNull() == serial
+                }?.let { return it }
+        }
+
+        return candidates.firstOrNull { candidate ->
+            candidate.vendorId == currentVendorId &&
+                candidate.productId == currentProductId &&
+                candidate.interfaceCount == currentInterfaceCount &&
+                candidate.manufacturerName.orEmpty() == currentManufacturer &&
+                candidate.productName.orEmpty() == currentProductName
+        } ?: currentDevice
+    }
+
     companion object {
+        private const val USB_RUNTIME_TAG = "DadbUsbRuntime"
+
         fun defaultStorageRoot(context: Context): File = File(context.filesDir, "adb_keys")
     }
 }

--- a/dadb-android/src/main/kotlin/dadb/android/runtime/AdbRuntime.kt
+++ b/dadb-android/src/main/kotlin/dadb/android/runtime/AdbRuntime.kt
@@ -120,16 +120,54 @@ class AdbRuntime(
         usbManager: UsbManager,
         usbDevice: UsbDevice,
         description: String = usbDevice.deviceName,
+        features: Set<String> = Dadb.connectFeatures(),
     ): Dadb {
         val keyPair = loadOrCreateKeyPair()
-        return Dadb.create(
-            UsbTransportFactory(
-                usbManager = usbManager,
-                usbDevice = usbDevice,
-                description = description,
-            ),
-            keyPair,
+        return createAndWarmUsbDadb(
+            usbManager = usbManager,
+            usbDevice = usbDevice,
+            description = description,
+            keyPair = keyPair,
+            features = features,
         )
+    }
+
+    private fun createAndWarmUsbDadb(
+        usbManager: UsbManager,
+        usbDevice: UsbDevice,
+        description: String,
+        keyPair: AdbKeyPair,
+        features: Set<String>,
+    ): Dadb {
+        var lastError: Throwable? = null
+
+        repeat(2) { attempt ->
+            val dadb =
+                Dadb.create(
+                    UsbTransportFactory(
+                        usbManager = usbManager,
+                        usbDevice = usbDevice,
+                        description = description,
+                    ),
+                    keyPair,
+                    features,
+                )
+
+            try {
+                // Warm the USB transport before returning so the caller does not pay the cost
+                // of discovering a stale first handshake/open on its first shell request.
+                dadb.supportsFeature("shell_v2")
+                return dadb
+            } catch (t: Throwable) {
+                lastError = t
+                runCatching { dadb.close() }
+                if (attempt == 0) {
+                    Thread.sleep(150)
+                }
+            }
+        }
+
+        throw lastError ?: IllegalStateException("Failed to create USB Dadb: $description")
     }
 
     companion object {

--- a/dadb-android/src/main/kotlin/dadb/android/runtime/AdbRuntime.kt
+++ b/dadb-android/src/main/kotlin/dadb/android/runtime/AdbRuntime.kt
@@ -32,7 +32,11 @@ class AdbRuntime(
         options: AdbRuntimeOptions = AdbRuntimeOptions(),
     ) : this(defaultStorageRoot(context), options)
 
-    private val identityStore = AdbIdentityStore(storageRoot)
+    private val identityStore =
+        AdbIdentityStore(storageRoot) {
+            options.identityLabel?.trim()?.takeIf { it.isNotEmpty() }
+                ?: AdbRuntimeIdentityLabel.defaultLabel()
+        }
 
     fun loadOrCreateKeyPair(): AdbKeyPair = identityStore.loadOrCreate()
 

--- a/dadb-android/src/main/kotlin/dadb/android/runtime/AdbRuntimeIdentity.kt
+++ b/dadb-android/src/main/kotlin/dadb/android/runtime/AdbRuntimeIdentity.kt
@@ -1,0 +1,7 @@
+package dadb.android.runtime
+
+@ExperimentalDadbAndroidApi
+data class AdbRuntimeIdentity(
+    val privateKey: String?,
+    val publicKey: String?,
+)

--- a/dadb-android/src/main/kotlin/dadb/android/runtime/AdbRuntimeIdentityLabel.kt
+++ b/dadb-android/src/main/kotlin/dadb/android/runtime/AdbRuntimeIdentityLabel.kt
@@ -1,0 +1,19 @@
+package dadb.android.runtime
+
+import android.os.Build
+
+internal object AdbRuntimeIdentityLabel {
+    private const val DEFAULT_SOFTWARE_NAME = "dadb-android"
+
+    fun defaultLabel(
+        softwareName: String = DEFAULT_SOFTWARE_NAME,
+    ): String {
+        val model =
+            Build.MODEL
+                ?.replace(" ", "")
+                ?.trim()
+                .orEmpty()
+                .ifBlank { "Android" }
+        return "$model@$softwareName"
+    }
+}

--- a/dadb-android/src/main/kotlin/dadb/android/runtime/AdbRuntimeOptions.kt
+++ b/dadb-android/src/main/kotlin/dadb/android/runtime/AdbRuntimeOptions.kt
@@ -1,0 +1,70 @@
+package dadb.android.runtime
+
+import dadb.android.tls.AdbTlsTrustManagers
+import javax.net.ssl.X509ExtendedTrustManager
+
+@ExperimentalDadbAndroidApi
+/**
+ * Options for the Android runtime helper layer.
+ *
+ * This layer does not persist trust state by itself. If you want TOFU, pin comparison, or identity
+ * change handling, observe [onServerTlsPeerObserved] and implement that policy in your own app
+ * storage.
+ */
+data class AdbRuntimeOptions(
+    val tlsTrustPolicy: AdbTlsTrustPolicy = AdbTlsTrustPolicy.TrustAll,
+    val onServerTlsPeerObserved: ((AdbTlsPeerIdentity) -> Unit)? = null,
+)
+
+@ExperimentalDadbAndroidApi
+/**
+ * Observed TLS server identity for a successful Wireless Debugging handshake.
+ *
+ * The runtime reports what it saw on the wire. Callers can ignore it, persist it, compare it to a
+ * previous observation, or surface it to users.
+ */
+data class AdbNetworkEndpoint(
+    val host: String,
+    val port: Int,
+) {
+    val authority: String
+        get() = "$host:$port"
+}
+
+@ExperimentalDadbAndroidApi
+data class AdbTlsPeerIdentity(
+    val target: AdbNetworkEndpoint,
+    val observedPinSha256Base64: String,
+)
+
+@ExperimentalDadbAndroidApi
+sealed interface AdbTlsTrustPolicy {
+    /**
+     * Accept any TLS server certificate presented by the peer.
+     *
+     * This is the default because Wireless Debugging commonly uses self-signed certificates.
+     * Callers that want endpoint validation, TOFU, or pin enforcement must implement that policy
+     * themselves, typically by combining this mode with [AdbRuntimeOptions.onServerTlsPeerObserved]
+     * or by supplying [Custom].
+     */
+    data object TrustAll : AdbTlsTrustPolicy
+
+    /**
+     * Provide a custom trust manager for TLS server verification.
+     */
+    class Custom(
+        val createTrustManager: (target: AdbNetworkEndpoint) -> X509ExtendedTrustManager,
+    ) : AdbTlsTrustPolicy
+}
+
+@OptIn(ExperimentalDadbAndroidApi::class)
+internal fun AdbTlsTrustPolicy.resolveTrustManager(
+    target: AdbNetworkEndpoint,
+): X509ExtendedTrustManager =
+    when (this) {
+        AdbTlsTrustPolicy.TrustAll ->
+            AdbTlsTrustManagers.createUnsafe()
+
+        is AdbTlsTrustPolicy.Custom ->
+            createTrustManager(target)
+    }

--- a/dadb-android/src/main/kotlin/dadb/android/runtime/AdbRuntimeOptions.kt
+++ b/dadb-android/src/main/kotlin/dadb/android/runtime/AdbRuntimeOptions.kt
@@ -14,6 +14,7 @@ import javax.net.ssl.X509ExtendedTrustManager
 data class AdbRuntimeOptions(
     val tlsTrustPolicy: AdbTlsTrustPolicy = AdbTlsTrustPolicy.TrustAll,
     val onServerTlsPeerObserved: ((AdbTlsPeerIdentity) -> Unit)? = null,
+    val identityLabel: String? = null,
 )
 
 @ExperimentalDadbAndroidApi
@@ -55,6 +56,15 @@ sealed interface AdbTlsTrustPolicy {
     class Custom(
         val createTrustManager: (target: AdbNetworkEndpoint) -> X509ExtendedTrustManager,
     ) : AdbTlsTrustPolicy
+
+    /**
+     * Require the TLS peer certificate public-key pin to match the expected value for the target.
+     */
+    class Pinned(
+        val expectedPinSha256Base64: (target: AdbNetworkEndpoint) -> String,
+    ) : AdbTlsTrustPolicy {
+        constructor(expectedPinSha256Base64: String) : this({ expectedPinSha256Base64 })
+    }
 }
 
 @OptIn(ExperimentalDadbAndroidApi::class)
@@ -64,6 +74,12 @@ internal fun AdbTlsTrustPolicy.resolveTrustManager(
     when (this) {
         AdbTlsTrustPolicy.TrustAll ->
             AdbTlsTrustManagers.createUnsafe()
+
+        is AdbTlsTrustPolicy.Pinned ->
+            AdbTlsTrustManagers.createPinned(
+                target = target,
+                expectedPinSha256Base64 = expectedPinSha256Base64(target),
+            )
 
         is AdbTlsTrustPolicy.Custom ->
             createTrustManager(target)

--- a/dadb-android/src/main/kotlin/dadb/android/runtime/ExperimentalDadbAndroidApi.kt
+++ b/dadb-android/src/main/kotlin/dadb/android/runtime/ExperimentalDadbAndroidApi.kt
@@ -1,0 +1,7 @@
+package dadb.android.runtime
+
+@RequiresOptIn(
+    level = RequiresOptIn.Level.WARNING,
+    message = "dadb-android runtime helpers are experimental and may change without notice.",
+)
+annotation class ExperimentalDadbAndroidApi

--- a/dadb-android/src/main/kotlin/dadb/android/storage/AdbIdentityStore.kt
+++ b/dadb-android/src/main/kotlin/dadb/android/storage/AdbIdentityStore.kt
@@ -5,14 +5,22 @@ import java.io.File
 
 class AdbIdentityStore(
     private val runtimeFiles: AdbRuntimeFiles,
+    private val identityLabel: () -> String = { "unknown@unknown" },
 ) {
-    constructor(rootDir: File) : this(AdbRuntimeFiles(rootDir))
+    constructor(
+        rootDir: File,
+        identityLabel: () -> String = { "unknown@unknown" },
+    ) : this(AdbRuntimeFiles(rootDir), identityLabel)
 
     fun loadOrCreate(): AdbKeyPair {
         runtimeFiles.ensureRootDirectory()
 
         if (!runtimeFiles.privateKeyFile.exists() || !runtimeFiles.publicKeyFile.exists()) {
-            AdbKeyPair.generate(runtimeFiles.privateKeyFile, runtimeFiles.publicKeyFile)
+            AdbKeyPair.generate(
+                runtimeFiles.privateKeyFile,
+                runtimeFiles.publicKeyFile,
+                publicKeyOwner = identityLabel(),
+            )
         }
 
         return AdbKeyPair.read(runtimeFiles.privateKeyFile, runtimeFiles.publicKeyFile)
@@ -27,7 +35,11 @@ class AdbIdentityStore(
             runtimeFiles.publicKeyFile.delete()
         }
 
-        AdbKeyPair.generate(runtimeFiles.privateKeyFile, runtimeFiles.publicKeyFile)
+        AdbKeyPair.generate(
+            runtimeFiles.privateKeyFile,
+            runtimeFiles.publicKeyFile,
+            publicKeyOwner = identityLabel(),
+        )
         return AdbKeyPair.read(runtimeFiles.privateKeyFile, runtimeFiles.publicKeyFile)
     }
 

--- a/dadb-android/src/main/kotlin/dadb/android/storage/AdbIdentityStore.kt
+++ b/dadb-android/src/main/kotlin/dadb/android/storage/AdbIdentityStore.kt
@@ -1,0 +1,65 @@
+package dadb.android.storage
+
+import dadb.AdbKeyPair
+import java.io.File
+
+class AdbIdentityStore(
+    private val runtimeFiles: AdbRuntimeFiles,
+) {
+    constructor(rootDir: File) : this(AdbRuntimeFiles(rootDir))
+
+    fun loadOrCreate(): AdbKeyPair {
+        runtimeFiles.ensureRootDirectory()
+
+        if (!runtimeFiles.privateKeyFile.exists() || !runtimeFiles.publicKeyFile.exists()) {
+            AdbKeyPair.generate(runtimeFiles.privateKeyFile, runtimeFiles.publicKeyFile)
+        }
+
+        return AdbKeyPair.read(runtimeFiles.privateKeyFile, runtimeFiles.publicKeyFile)
+    }
+
+    fun regenerate(): AdbKeyPair {
+        runtimeFiles.ensureRootDirectory()
+        if (runtimeFiles.privateKeyFile.exists()) {
+            runtimeFiles.privateKeyFile.delete()
+        }
+        if (runtimeFiles.publicKeyFile.exists()) {
+            runtimeFiles.publicKeyFile.delete()
+        }
+
+        AdbKeyPair.generate(runtimeFiles.privateKeyFile, runtimeFiles.publicKeyFile)
+        return AdbKeyPair.read(runtimeFiles.privateKeyFile, runtimeFiles.publicKeyFile)
+    }
+
+    fun replace(
+        privateKey: String,
+        publicKey: String,
+    ): Boolean {
+        runtimeFiles.ensureRootDirectory()
+        val identityChanged =
+            readPrivateKey() != privateKey ||
+                readPublicKey() != publicKey
+
+        runtimeFiles.privateKeyFile.writeText(privateKey)
+        runtimeFiles.publicKeyFile.writeText(publicKey)
+        return identityChanged
+    }
+
+    fun readPrivateKey(): String? {
+        runtimeFiles.ensureRootDirectory()
+        if (!runtimeFiles.privateKeyFile.exists()) {
+            return null
+        }
+
+        return runtimeFiles.privateKeyFile.readText()
+    }
+
+    fun readPublicKey(): String? {
+        runtimeFiles.ensureRootDirectory()
+        if (!runtimeFiles.publicKeyFile.exists()) {
+            return null
+        }
+
+        return runtimeFiles.publicKeyFile.readText()
+    }
+}

--- a/dadb-android/src/main/kotlin/dadb/android/storage/AdbRuntimeFiles.kt
+++ b/dadb-android/src/main/kotlin/dadb/android/storage/AdbRuntimeFiles.kt
@@ -1,0 +1,22 @@
+package dadb.android.storage
+
+import java.io.File
+
+class AdbRuntimeFiles(
+    val rootDir: File,
+) {
+    val privateKeyFile: File
+        get() = File(rootDir, "adbkey")
+
+    val publicKeyFile: File
+        get() = File(rootDir, "adbkey.pub")
+
+    fun ensureRootDirectory() {
+        if (rootDir.exists()) {
+            check(rootDir.isDirectory) { "ADB storage root is not a directory: ${rootDir.absolutePath}" }
+            return
+        }
+
+        check(rootDir.mkdirs()) { "Failed to create ADB storage root: ${rootDir.absolutePath}" }
+    }
+}

--- a/dadb-android/src/main/kotlin/dadb/android/tls/AdbTlsAuthException.kt
+++ b/dadb-android/src/main/kotlin/dadb/android/tls/AdbTlsAuthException.kt
@@ -1,0 +1,8 @@
+package dadb.android.tls
+
+import java.io.IOException
+
+/**
+ * The remote Wireless Debugging peer rejected the TLS handshake because pairing or trust is missing.
+ */
+class AdbTlsAuthException : IOException("TLS peer rejected authentication or trust is missing")

--- a/dadb-android/src/main/kotlin/dadb/android/tls/AdbTlsCertificatePins.kt
+++ b/dadb-android/src/main/kotlin/dadb/android/tls/AdbTlsCertificatePins.kt
@@ -2,13 +2,13 @@ package dadb.android.tls
 
 import java.security.MessageDigest
 import java.security.cert.X509Certificate
-import java.util.Base64
+import okio.ByteString.Companion.toByteString
 
 object AdbTlsCertificatePins {
     fun publicKeySha256Base64(certificate: X509Certificate): String = sha256Base64(certificate.publicKey.encoded)
 
     fun sha256Base64(data: ByteArray): String {
         val digest = MessageDigest.getInstance("SHA-256").digest(data)
-        return Base64.getEncoder().encodeToString(digest)
+        return digest.toByteString().base64()
     }
 }

--- a/dadb-android/src/main/kotlin/dadb/android/tls/AdbTlsCertificatePins.kt
+++ b/dadb-android/src/main/kotlin/dadb/android/tls/AdbTlsCertificatePins.kt
@@ -1,0 +1,14 @@
+package dadb.android.tls
+
+import java.security.MessageDigest
+import java.security.cert.X509Certificate
+import java.util.Base64
+
+object AdbTlsCertificatePins {
+    fun publicKeySha256Base64(certificate: X509Certificate): String = sha256Base64(certificate.publicKey.encoded)
+
+    fun sha256Base64(data: ByteArray): String {
+        val digest = MessageDigest.getInstance("SHA-256").digest(data)
+        return Base64.getEncoder().encodeToString(digest)
+    }
+}

--- a/dadb-android/src/main/kotlin/dadb/android/tls/AdbTlsContexts.kt
+++ b/dadb-android/src/main/kotlin/dadb/android/tls/AdbTlsContexts.kt
@@ -1,0 +1,133 @@
+package dadb.android.tls
+
+import dadb.AdbKeyPair
+import java.io.ByteArrayInputStream
+import java.math.BigInteger
+import java.net.Socket
+import java.security.KeyFactory
+import java.security.PrivateKey
+import java.security.Provider
+import java.security.SecureRandom
+import java.security.Security
+import java.security.cert.CertificateFactory
+import java.security.cert.X509Certificate
+import java.security.interfaces.RSAPrivateKey
+import java.security.interfaces.RSAPublicKey
+import java.security.spec.RSAPublicKeySpec
+import javax.net.ssl.SSLContext
+import javax.net.ssl.SSLEngine
+import javax.net.ssl.X509ExtendedKeyManager
+import javax.net.ssl.X509ExtendedTrustManager
+import org.bouncycastle.asn1.x500.X500Name
+import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo
+import org.bouncycastle.cert.X509v3CertificateBuilder
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder
+import org.conscrypt.Conscrypt
+
+internal object AdbTlsContexts {
+    fun create(
+        keyPair: AdbKeyPair,
+        trustManager: X509ExtendedTrustManager,
+    ): SSLContext {
+        val privateKey = keyPair.privateKey()
+        val certificate = createCertificate(privateKey)
+
+        return runCatching {
+            val conscryptProvider = ensureConscryptProvider()
+            SSLContext.getInstance("TLSv1.3", conscryptProvider)
+        }.recoverCatching {
+            SSLContext.getInstance("TLSv1.3")
+        }.recoverCatching {
+            SSLContext.getInstance("TLS")
+        }.getOrThrow().apply {
+            init(
+                arrayOf(createKeyManager(privateKey, certificate)),
+                arrayOf(trustManager),
+                SecureRandom(),
+            )
+        }
+    }
+
+    fun createUnsafe(keyPair: AdbKeyPair): SSLContext = create(keyPair, createInsecureTrustManager())
+
+    private fun createCertificate(privateKey: PrivateKey): X509Certificate {
+        val rsaPrivateKey =
+            privateKey as? RSAPrivateKey
+                ?: throw IllegalStateException("Wireless Debugging TLS requires an RSA private key")
+
+        val rsaPublicKey =
+            KeyFactory.getInstance("RSA")
+                .generatePublic(RSAPublicKeySpec(rsaPrivateKey.modulus, BigInteger.valueOf(65537L))) as RSAPublicKey
+
+        val signer = JcaContentSignerBuilder("SHA256withRSA").build(rsaPrivateKey)
+        val builder =
+            X509v3CertificateBuilder(
+                X500Name("CN=00"),
+                BigInteger.ONE,
+                java.util.Date(0),
+                java.util.Date(2_461_449_600_000L),
+                X500Name("CN=00"),
+                SubjectPublicKeyInfo.getInstance(rsaPublicKey.encoded),
+            )
+        val encoded = builder.build(signer).encoded
+
+        return CertificateFactory.getInstance("X.509")
+            .generateCertificate(ByteArrayInputStream(encoded)) as X509Certificate
+    }
+
+    private fun createKeyManager(
+        privateKey: PrivateKey,
+        certificate: X509Certificate,
+    ): X509ExtendedKeyManager =
+        object : X509ExtendedKeyManager() {
+            private val keyAlias = "adbkey"
+
+            override fun chooseClientAlias(
+                keyType: Array<out String>?,
+                issuers: Array<out java.security.Principal>?,
+                socket: Socket?,
+            ): String = keyAlias
+
+            override fun getCertificateChain(alias: String?): Array<X509Certificate>? =
+                if (alias == keyAlias) {
+                    arrayOf(certificate)
+                } else {
+                    null
+                }
+
+            override fun getPrivateKey(alias: String?): PrivateKey? =
+                if (alias == keyAlias) {
+                    privateKey
+                } else {
+                    null
+                }
+
+            override fun getClientAliases(
+                keyType: String?,
+                issuers: Array<out java.security.Principal>?,
+            ): Array<String>? = null
+
+            override fun getServerAliases(
+                keyType: String?,
+                issuers: Array<out java.security.Principal>?,
+            ): Array<String>? = null
+
+            override fun chooseServerAlias(
+                keyType: String?,
+                issuers: Array<out java.security.Principal>?,
+                socket: Socket?,
+            ): String? = null
+        }
+
+    @Suppress("CustomX509TrustManager", "TrustAllX509TrustManager")
+    private fun createInsecureTrustManager(): X509ExtendedTrustManager =
+        AdbTlsTrustManagers.createUnsafe()
+
+    private fun ensureConscryptProvider(): Provider {
+        val provider = Conscrypt.newProviderBuilder().build()
+        if (Security.getProvider(provider.name) == null) {
+            Security.insertProviderAt(provider, 1)
+        }
+        return provider
+    }
+}

--- a/dadb-android/src/main/kotlin/dadb/android/tls/AdbTlsContexts.kt
+++ b/dadb-android/src/main/kotlin/dadb/android/tls/AdbTlsContexts.kt
@@ -88,6 +88,12 @@ internal object AdbTlsContexts {
                 socket: Socket?,
             ): String = keyAlias
 
+            override fun chooseEngineClientAlias(
+                keyType: Array<out String>?,
+                issuers: Array<out java.security.Principal>?,
+                engine: SSLEngine?,
+            ): String = keyAlias
+
             override fun getCertificateChain(alias: String?): Array<X509Certificate>? =
                 if (alias == keyAlias) {
                     arrayOf(certificate)
@@ -105,7 +111,7 @@ internal object AdbTlsContexts {
             override fun getClientAliases(
                 keyType: String?,
                 issuers: Array<out java.security.Principal>?,
-            ): Array<String>? = null
+            ): Array<String> = arrayOf(keyAlias)
 
             override fun getServerAliases(
                 keyType: String?,

--- a/dadb-android/src/main/kotlin/dadb/android/tls/AdbTlsErrorMapper.kt
+++ b/dadb-android/src/main/kotlin/dadb/android/tls/AdbTlsErrorMapper.kt
@@ -1,0 +1,46 @@
+package dadb.android.tls
+
+import java.io.IOException
+import java.net.SocketTimeoutException
+import java.nio.channels.InterruptedByTimeoutException
+import javax.net.ssl.SSLException
+import javax.net.ssl.SSLHandshakeException
+import javax.net.ssl.SSLProtocolException
+
+internal object AdbTlsErrorMapper {
+    fun map(throwable: Throwable): Throwable {
+        val messages =
+            buildString {
+                generateSequence(throwable) { it.cause }.forEach { cause ->
+                    cause.message?.let {
+                        append(it.lowercase())
+                        append('\n')
+                    }
+                }
+            }
+
+        if (
+            messages.contains("certificate_required") ||
+            messages.contains("unknown_ca") ||
+            messages.contains("access_denied") ||
+            messages.contains("certificate_unknown")
+        ) {
+            return AdbTlsAuthException()
+        }
+
+        if (generateSequence(throwable) { it.cause }.any { it is InterruptedByTimeoutException || it is SocketTimeoutException }) {
+            return IOException("TLS handshake timeout", throwable)
+        }
+
+        if (
+            generateSequence(throwable) { it.cause }.any {
+                it is SSLHandshakeException || it is SSLProtocolException || it is SSLException
+            }
+        ) {
+            val message = throwable.message ?: ""
+            return IOException("TLS handshake failed${if (message.isNotEmpty()) ": $message" else ""}", throwable)
+        }
+
+        return throwable
+    }
+}

--- a/dadb-android/src/main/kotlin/dadb/android/tls/AdbTlsPinMismatchException.kt
+++ b/dadb-android/src/main/kotlin/dadb/android/tls/AdbTlsPinMismatchException.kt
@@ -1,0 +1,11 @@
+package dadb.android.tls
+
+import java.security.cert.CertificateException
+
+class AdbTlsPinMismatchException(
+    val expectedPinSha256Base64: String,
+    val observedPinSha256Base64: String,
+    targetAuthority: String,
+) : CertificateException(
+        "TLS peer pin mismatch for $targetAuthority: expected=$expectedPinSha256Base64 observed=$observedPinSha256Base64",
+    )

--- a/dadb-android/src/main/kotlin/dadb/android/tls/AdbTlsSockets.kt
+++ b/dadb-android/src/main/kotlin/dadb/android/tls/AdbTlsSockets.kt
@@ -1,0 +1,25 @@
+package dadb.android.tls
+
+import javax.net.ssl.SSLSocket
+
+internal object AdbTlsSockets {
+    private const val TLS_V1_3 = "TLSv1.3"
+
+    fun configureClientSocket(
+        sslSocket: SSLSocket,
+        socketTimeout: Int,
+        configureSocket: (SSLSocket) -> Unit = {},
+    ) {
+        sslSocket.useClientMode = true
+        sslSocket.soTimeout = socketTimeout
+        sslSocket.enabledProtocols = requiredClientProtocols(sslSocket.supportedProtocols)
+        configureSocket(sslSocket)
+    }
+
+    internal fun requiredClientProtocols(supportedProtocols: Array<String>): Array<String> {
+        check(supportedProtocols.contains(TLS_V1_3)) {
+            "Wireless Debugging TLS requires TLSv1.3, but the current runtime only supports: ${supportedProtocols.joinToString()}"
+        }
+        return arrayOf(TLS_V1_3)
+    }
+}

--- a/dadb-android/src/main/kotlin/dadb/android/tls/AdbTlsTrustManagers.kt
+++ b/dadb-android/src/main/kotlin/dadb/android/tls/AdbTlsTrustManagers.kt
@@ -1,10 +1,14 @@
 package dadb.android.tls
 
+import dadb.android.runtime.AdbNetworkEndpoint
+import dadb.android.runtime.ExperimentalDadbAndroidApi
 import java.net.Socket
+import java.security.cert.CertificateException
 import java.security.cert.X509Certificate
 import javax.net.ssl.SSLEngine
 import javax.net.ssl.X509ExtendedTrustManager
 
+@OptIn(ExperimentalDadbAndroidApi::class)
 internal object AdbTlsTrustManagers {
     fun createUnsafe(): X509ExtendedTrustManager =
         object : X509ExtendedTrustManager() {
@@ -53,4 +57,59 @@ internal object AdbTlsTrustManagers {
             override fun getAcceptedIssuers(): Array<X509Certificate> = emptyArray()
         }
 
+    fun createPinned(
+        target: AdbNetworkEndpoint,
+        expectedPinSha256Base64: String,
+    ): X509ExtendedTrustManager =
+        object : X509ExtendedTrustManager() {
+            private fun checkPinnedChain(chain: Array<out X509Certificate>?) {
+                val leaf =
+                    chain?.firstOrNull()
+                        ?: throw CertificateException("TLS peer did not present a certificate for ${target.authority}")
+                val observedPin = AdbTlsCertificatePins.publicKeySha256Base64(leaf)
+                if (observedPin != expectedPinSha256Base64) {
+                    throw AdbTlsPinMismatchException(
+                        expectedPinSha256Base64 = expectedPinSha256Base64,
+                        observedPinSha256Base64 = observedPin,
+                        targetAuthority = target.authority,
+                    )
+                }
+            }
+
+            override fun checkClientTrusted(
+                chain: Array<out X509Certificate>?,
+                authType: String?,
+                socket: Socket?,
+            ) = Unit
+
+            override fun checkClientTrusted(
+                chain: Array<out X509Certificate>?,
+                authType: String?,
+                engine: SSLEngine?,
+            ) = Unit
+
+            override fun checkClientTrusted(
+                chain: Array<out X509Certificate>?,
+                authType: String?,
+            ) = Unit
+
+            override fun checkServerTrusted(
+                chain: Array<out X509Certificate>?,
+                authType: String?,
+                socket: Socket?,
+            ) = checkPinnedChain(chain)
+
+            override fun checkServerTrusted(
+                chain: Array<out X509Certificate>?,
+                authType: String?,
+                engine: SSLEngine?,
+            ) = checkPinnedChain(chain)
+
+            override fun checkServerTrusted(
+                chain: Array<out X509Certificate>?,
+                authType: String?,
+            ) = checkPinnedChain(chain)
+
+            override fun getAcceptedIssuers(): Array<X509Certificate> = emptyArray()
+        }
 }

--- a/dadb-android/src/main/kotlin/dadb/android/tls/AdbTlsTrustManagers.kt
+++ b/dadb-android/src/main/kotlin/dadb/android/tls/AdbTlsTrustManagers.kt
@@ -1,0 +1,56 @@
+package dadb.android.tls
+
+import java.net.Socket
+import java.security.cert.X509Certificate
+import javax.net.ssl.SSLEngine
+import javax.net.ssl.X509ExtendedTrustManager
+
+internal object AdbTlsTrustManagers {
+    fun createUnsafe(): X509ExtendedTrustManager =
+        object : X509ExtendedTrustManager() {
+            private fun accept(
+                chain: Array<out X509Certificate>?,
+                authType: String?,
+            ) {
+                if (chain.isNullOrEmpty()) return
+                if (authType.isNullOrBlank()) return
+            }
+
+            override fun checkClientTrusted(
+                chain: Array<out X509Certificate>?,
+                authType: String?,
+                socket: Socket?,
+            ) = accept(chain, authType)
+
+            override fun checkClientTrusted(
+                chain: Array<out X509Certificate>?,
+                authType: String?,
+                engine: SSLEngine?,
+            ) = accept(chain, authType)
+
+            override fun checkClientTrusted(
+                chain: Array<out X509Certificate>?,
+                authType: String?,
+            ) = accept(chain, authType)
+
+            override fun checkServerTrusted(
+                chain: Array<out X509Certificate>?,
+                authType: String?,
+                socket: Socket?,
+            ) = accept(chain, authType)
+
+            override fun checkServerTrusted(
+                chain: Array<out X509Certificate>?,
+                authType: String?,
+                engine: SSLEngine?,
+            ) = accept(chain, authType)
+
+            override fun checkServerTrusted(
+                chain: Array<out X509Certificate>?,
+                authType: String?,
+            ) = accept(chain, authType)
+
+            override fun getAcceptedIssuers(): Array<X509Certificate> = emptyArray()
+        }
+
+}

--- a/dadb-android/src/main/kotlin/dadb/android/tls/TlsAdbTransportFactory.kt
+++ b/dadb-android/src/main/kotlin/dadb/android/tls/TlsAdbTransportFactory.kt
@@ -1,0 +1,148 @@
+package dadb.android.tls
+
+import dadb.AdbKeyPair
+import dadb.AdbTransport
+import dadb.AdbTransportFactory
+import dadb.TlsUpgradableAdbTransport
+import java.net.InetSocketAddress
+import java.net.Socket
+import java.util.concurrent.atomic.AtomicBoolean
+import javax.net.ssl.SSLSocket
+import javax.net.ssl.SSLSocketFactory
+import javax.net.ssl.X509ExtendedTrustManager
+import okio.Sink
+import okio.Source
+import okio.sink
+import okio.source
+
+/**
+ * STLS-aware ADB transport for Wireless Debugging.
+ *
+ * The connection starts as a normal TCP socket. If the device responds with `A_STLS`, dadb core
+ * will request the upgrade and then call [TlsUpgradableAdbTransport.upgradeToTls] on this
+ * transport to wrap the same socket in TLS before continuing the normal ADB handshake.
+ *
+ * The convenience constructor that only takes an [AdbKeyPair] uses an insecure trust policy so it
+ * can interoperate with self-signed Wireless Debugging peers. Callers that have a stricter trust
+ * strategy should provide a custom [SSLSocketFactory] or [X509ExtendedTrustManager].
+ */
+class TlsAdbTransportFactory(
+    private val host: String,
+    private val port: Int,
+    private val socketFactory: SSLSocketFactory,
+    private val connectTimeout: Int = 0,
+    private val socketTimeout: Int = 0,
+    private val configureSocket: (SSLSocket) -> Unit = {},
+    private val onHandshakeCompleted: (SSLSocket) -> Unit = {},
+) : AdbTransportFactory {
+    constructor(
+        host: String,
+        port: Int,
+        keyPair: AdbKeyPair,
+        connectTimeout: Int = 0,
+        socketTimeout: Int = 0,
+        configureSocket: (SSLSocket) -> Unit = {},
+        onHandshakeCompleted: (SSLSocket) -> Unit = {},
+    ) : this(
+        host = host,
+        port = port,
+        socketFactory = AdbTlsContexts.createUnsafe(keyPair).socketFactory,
+        connectTimeout = connectTimeout,
+        socketTimeout = socketTimeout,
+        configureSocket = configureSocket,
+        onHandshakeCompleted = onHandshakeCompleted,
+    )
+
+    constructor(
+        host: String,
+        port: Int,
+        keyPair: AdbKeyPair,
+        trustManager: X509ExtendedTrustManager,
+        connectTimeout: Int = 0,
+        socketTimeout: Int = 0,
+        configureSocket: (SSLSocket) -> Unit = {},
+        onHandshakeCompleted: (SSLSocket) -> Unit = {},
+    ) : this(
+        host = host,
+        port = port,
+        socketFactory = AdbTlsContexts.create(keyPair, trustManager).socketFactory,
+        connectTimeout = connectTimeout,
+        socketTimeout = socketTimeout,
+        configureSocket = configureSocket,
+        onHandshakeCompleted = onHandshakeCompleted,
+    )
+
+    override val description: String = "$host:$port"
+
+    override fun connect(): AdbTransport {
+        val socket = Socket()
+        socket.soTimeout = socketTimeout
+        socket.connect(InetSocketAddress(host, port), connectTimeout)
+        return UpgradableTlsSocketAdbTransport(
+            socket = socket,
+            host = host,
+            port = port,
+            socketFactory = socketFactory,
+            socketTimeout = socketTimeout,
+            description = description,
+            configureSocket = configureSocket,
+            onHandshakeCompleted = onHandshakeCompleted,
+        )
+    }
+}
+
+private class UpgradableTlsSocketAdbTransport(
+    private val socket: Socket,
+    private val host: String,
+    private val port: Int,
+    private val socketFactory: SSLSocketFactory,
+    private val socketTimeout: Int,
+    override val description: String,
+    private val configureSocket: (SSLSocket) -> Unit,
+    private val onHandshakeCompleted: (SSLSocket) -> Unit,
+) : TlsUpgradableAdbTransport {
+    companion object {
+        private const val STLS_VERSION = 0x01000000
+    }
+
+    private val closed = AtomicBoolean(false)
+    private var currentSocket: Socket = socket
+    private var currentSource: Source = socket.source()
+    private var currentSink: Sink = socket.sink()
+
+    override val source: Source
+        get() = currentSource
+
+    override val sink: Sink
+        get() = currentSink
+
+    override val isClosed: Boolean
+        get() = closed.get() || currentSocket.isClosed
+
+    override fun upgradeToTls(version: Int) {
+        check(version >= STLS_VERSION) { "Unsupported STLS version: $version" }
+        val sslSocket =
+            socketFactory.createSocket(currentSocket, host, port, true) as SSLSocket
+
+        try {
+            sslSocket.useClientMode = true
+            sslSocket.soTimeout = socketTimeout
+            configureSocket(sslSocket)
+            sslSocket.startHandshake()
+            onHandshakeCompleted(sslSocket)
+            currentSocket = sslSocket
+            currentSource = sslSocket.source()
+            currentSink = sslSocket.sink()
+        } catch (t: Throwable) {
+            runCatching { sslSocket.close() }
+            throw t
+        }
+    }
+
+    override fun close() {
+        if (!closed.compareAndSet(false, true)) {
+            return
+        }
+        currentSocket.close()
+    }
+}

--- a/dadb-android/src/main/kotlin/dadb/android/tls/TlsAdbTransportFactory.kt
+++ b/dadb-android/src/main/kotlin/dadb/android/tls/TlsAdbTransportFactory.kt
@@ -14,6 +14,8 @@ import okio.Sink
 import okio.Source
 import okio.sink
 import okio.source
+import okio.Buffer
+import okio.Timeout
 
 /**
  * STLS-aware ADB transport for Wireless Debugging.
@@ -125,17 +127,15 @@ private class UpgradableTlsSocketAdbTransport(
             socketFactory.createSocket(currentSocket, host, port, true) as SSLSocket
 
         try {
-            sslSocket.useClientMode = true
-            sslSocket.soTimeout = socketTimeout
-            configureSocket(sslSocket)
+            AdbTlsSockets.configureClientSocket(sslSocket, socketTimeout, configureSocket)
             sslSocket.startHandshake()
             onHandshakeCompleted(sslSocket)
             currentSocket = sslSocket
-            currentSource = sslSocket.source()
-            currentSink = sslSocket.sink()
+            currentSource = TlsMappedSource(sslSocket.source())
+            currentSink = TlsMappedSink(sslSocket.sink())
         } catch (t: Throwable) {
             runCatching { sslSocket.close() }
-            throw t
+            throw AdbTlsErrorMapper.map(t)
         }
     }
 
@@ -145,4 +145,43 @@ private class UpgradableTlsSocketAdbTransport(
         }
         currentSocket.close()
     }
+}
+
+private class TlsMappedSource(
+    private val delegate: Source,
+) : Source {
+    override fun read(sink: Buffer, byteCount: Long): Long =
+        try {
+            delegate.read(sink, byteCount)
+        } catch (t: Throwable) {
+            throw AdbTlsErrorMapper.map(t)
+        }
+
+    override fun timeout(): Timeout = delegate.timeout()
+
+    override fun close() = delegate.close()
+}
+
+private class TlsMappedSink(
+    private val delegate: Sink,
+) : Sink {
+    override fun write(source: Buffer, byteCount: Long) {
+        try {
+            delegate.write(source, byteCount)
+        } catch (t: Throwable) {
+            throw AdbTlsErrorMapper.map(t)
+        }
+    }
+
+    override fun flush() {
+        try {
+            delegate.flush()
+        } catch (t: Throwable) {
+            throw AdbTlsErrorMapper.map(t)
+        }
+    }
+
+    override fun timeout(): Timeout = delegate.timeout()
+
+    override fun close() = delegate.close()
 }

--- a/dadb-android/src/main/kotlin/dadb/android/usb/AdbPacketCodec.kt
+++ b/dadb-android/src/main/kotlin/dadb/android/usb/AdbPacketCodec.kt
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2021 mobile.dev inc.
+ * Android USB transport support by github.com/XRSec/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package dadb.android.usb
+
+import okio.Buffer
+import java.io.IOException
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+
+internal object AdbPacketCodec {
+
+    const val HEADER_LENGTH = 24
+
+    private const val CMD_AUTH = 0x48545541
+    private const val CMD_CNXN = 0x4e584e43
+    private const val CMD_OPEN = 0x4e45504f
+    private const val CMD_OKAY = 0x59414b4f
+    private const val CMD_CLSE = 0x45534c43
+    private const val CMD_WRTE = 0x45545257
+    private const val MAX_PAYLOAD_LENGTH = 1024 * 1024
+
+    private val validCommands = setOf(
+        CMD_AUTH,
+        CMD_CNXN,
+        CMD_OPEN,
+        CMD_OKAY,
+        CMD_CLSE,
+        CMD_WRTE,
+    )
+
+    data class Header(
+        val command: Int,
+        val arg0: Int,
+        val arg1: Int,
+        val payloadLength: Int,
+        val checksum: Int,
+        val magic: Int,
+    )
+
+    @Throws(IOException::class)
+    fun parseHeader(headerBytes: ByteArray): Header {
+        require(headerBytes.size == HEADER_LENGTH) {
+            "ADB header must be $HEADER_LENGTH bytes, was ${headerBytes.size}"
+        }
+
+        val header = ByteBuffer.wrap(headerBytes).order(ByteOrder.LITTLE_ENDIAN)
+        val packetHeader = Header(
+            command = header.getInt(),
+            arg0 = header.getInt(),
+            arg1 = header.getInt(),
+            payloadLength = header.getInt(),
+            checksum = header.getInt(),
+            magic = header.getInt(),
+        )
+
+        validateHeader(packetHeader)
+        return packetHeader
+    }
+
+    @Throws(IOException::class)
+    fun completePacketLength(buffer: Buffer): Long? {
+        if (buffer.size < HEADER_LENGTH) {
+            return null
+        }
+
+        val headerBytes = buffer.copy().readByteArray(HEADER_LENGTH.toLong())
+        val header = parseHeader(headerBytes)
+        val packetLength = HEADER_LENGTH + header.payloadLength.toLong()
+        return if (buffer.size >= packetLength) packetLength else null
+    }
+
+    @Throws(IOException::class)
+    private fun validateHeader(header: Header) {
+        if (header.command !in validCommands) {
+            throw IOException("Unknown ADB command: 0x${header.command.toUInt().toString(16)}")
+        }
+        if (header.magic != (header.command xor -0x1)) {
+            throw IOException("Invalid ADB magic for command 0x${header.command.toUInt().toString(16)}: ${header.magic}")
+        }
+        if (header.payloadLength < 0 || header.payloadLength > MAX_PAYLOAD_LENGTH) {
+            throw IOException("Invalid ADB payload length: ${header.payloadLength}")
+        }
+    }
+}

--- a/dadb-android/src/main/kotlin/dadb/android/usb/UsbChannel.kt
+++ b/dadb-android/src/main/kotlin/dadb/android/usb/UsbChannel.kt
@@ -23,6 +23,7 @@ import android.hardware.usb.UsbDeviceConnection
 import android.hardware.usb.UsbEndpoint
 import android.hardware.usb.UsbInterface
 import android.hardware.usb.UsbManager
+import android.util.Log
 import java.io.IOException
 import java.nio.ByteBuffer
 import java.util.concurrent.LinkedBlockingQueue
@@ -35,6 +36,9 @@ internal class UsbChannel(
     private val readTimeoutMs: Int,
     private val readIdleTimeoutMs: Int,
 ) : AutoCloseable {
+    private companion object {
+        private const val TAG = "DadbUsbChannel"
+    }
 
     private val connection: UsbDeviceConnection =
         usbManager.openDevice(usbDevice)
@@ -66,6 +70,11 @@ internal class UsbChannel(
         val endpoints = findBulkEndpoints()
         endpointIn = endpoints.first ?: throw IOException("Bulk IN endpoint not found")
         endpointOut = endpoints.second ?: throw IOException("Bulk OUT endpoint not found")
+        Log.d(
+            TAG,
+            "UsbChannel init device=${usbDevice.deviceName} in=${endpointIn.address}/${endpointIn.maxPacketSize} " +
+                "out=${endpointOut.address}/${endpointOut.maxPacketSize}",
+        )
 
         readerThread.start()
     }
@@ -133,14 +142,13 @@ internal class UsbChannel(
             return
         }
         closed = true
+        Log.d(TAG, "UsbChannel close start device=${usbDevice.deviceName}")
         incomingChunks.offer(ByteArray(0))
 
         try {
             readerThread.interrupt()
         } catch (_: Exception) {
         }
-
-        resetTransport()
 
         try {
             connection.releaseInterface(usbInterface)
@@ -151,6 +159,7 @@ internal class UsbChannel(
             connection.close()
         } catch (_: Exception) {
         }
+        Log.d(TAG, "UsbChannel close complete device=${usbDevice.deviceName}")
     }
 
     private fun findAdbInterface(): UsbInterface? {
@@ -208,6 +217,7 @@ internal class UsbChannel(
         } catch (t: Throwable) {
             if (!closed) {
                 readError = t
+                Log.w(TAG, "UsbChannel reader stopped device=${usbDevice.deviceName}: ${t.javaClass.simpleName}: ${t.message}", t)
             }
         } finally {
             incomingChunks.offer(ByteArray(0))
@@ -238,12 +248,5 @@ internal class UsbChannel(
         }
 
         return buffer
-    }
-
-    private fun resetTransport() {
-        try {
-            connection.bulkTransfer(endpointOut, ByteArray(100), 100, 100)
-        } catch (_: Exception) {
-        }
     }
 }

--- a/dadb-android/src/main/kotlin/dadb/android/usb/UsbChannel.kt
+++ b/dadb-android/src/main/kotlin/dadb/android/usb/UsbChannel.kt
@@ -1,0 +1,249 @@
+/*
+ * Copyright (c) 2021 mobile.dev inc.
+ * Android USB transport support by github.com/XRSec/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package dadb.android.usb
+
+import android.hardware.usb.UsbDevice
+import android.hardware.usb.UsbDeviceConnection
+import android.hardware.usb.UsbEndpoint
+import android.hardware.usb.UsbInterface
+import android.hardware.usb.UsbManager
+import java.io.IOException
+import java.nio.ByteBuffer
+import java.util.concurrent.LinkedBlockingQueue
+
+internal class UsbChannel(
+    usbManager: UsbManager,
+    private val usbDevice: UsbDevice,
+    private val maxPacketSize: Int,
+    private val writeTimeoutMs: Int,
+    private val readTimeoutMs: Int,
+    private val readIdleTimeoutMs: Int,
+) : AutoCloseable {
+
+    private val connection: UsbDeviceConnection =
+        usbManager.openDevice(usbDevice)
+            ?: throw IOException("Failed to open USB device: ${usbDevice.deviceName}")
+    private val usbInterface: UsbInterface
+    private val endpointIn: UsbEndpoint
+    private val endpointOut: UsbEndpoint
+    private val incomingChunks = LinkedBlockingQueue<ByteArray>()
+    private val readerThread = Thread(::readMessages, "dadb-usb-reader")
+
+    @Volatile
+    private var closed = false
+
+    @Volatile
+    private var readError: Throwable? = null
+
+    private var currentChunk: ByteArray? = null
+    private var currentChunkOffset = 0
+
+    init {
+        usbInterface = findAdbInterface()
+            ?: throw IOException("ADB interface not found on device: ${usbDevice.deviceName}")
+
+        if (!connection.claimInterface(usbInterface, true)) {
+            connection.close()
+            throw IOException("Failed to claim USB interface")
+        }
+
+        val endpoints = findBulkEndpoints()
+        endpointIn = endpoints.first ?: throw IOException("Bulk IN endpoint not found")
+        endpointOut = endpoints.second ?: throw IOException("Bulk OUT endpoint not found")
+
+        readerThread.start()
+    }
+
+    fun write(data: ByteArray) {
+        val buffer = ByteBuffer.wrap(data)
+        while (buffer.remaining() > 0) {
+            if (buffer.remaining() < AdbPacketCodec.HEADER_LENGTH) {
+                throw IOException("Incomplete ADB packet header: remaining=${buffer.remaining()}")
+            }
+
+            val header = ByteArray(AdbPacketCodec.HEADER_LENGTH)
+            buffer.get(header)
+            val packetHeader = AdbPacketCodec.parseHeader(header)
+            transferOut(header)
+
+            if (buffer.remaining() < packetHeader.payloadLength) {
+                throw IOException(
+                    "Incomplete ADB packet payload: required=${packetHeader.payloadLength}, remaining=${buffer.remaining()}",
+                )
+            }
+
+            if (packetHeader.payloadLength > 0) {
+                val payload = ByteArray(packetHeader.payloadLength)
+                buffer.get(payload)
+                transferOut(payload)
+            }
+        }
+    }
+
+    fun readAtMost(size: Int): ByteArray {
+        require(size > 0) { "size must be > 0" }
+
+        while (true) {
+            val chunk = currentChunk
+            if (chunk != null && currentChunkOffset < chunk.size) {
+                val copyLength = minOf(size, chunk.size - currentChunkOffset)
+                val result = chunk.copyOfRange(currentChunkOffset, currentChunkOffset + copyLength)
+                currentChunkOffset += copyLength
+                if (currentChunkOffset >= chunk.size) {
+                    currentChunk = null
+                    currentChunkOffset = 0
+                }
+                return result
+            }
+
+            val nextChunk = incomingChunks.take()
+            if (nextChunk.isEmpty()) {
+                val error = readError
+                if (error != null) {
+                    throw IOException("USB read failed: ${error.message}", error)
+                }
+                throw IOException("USB channel closed: ${usbDevice.deviceName}")
+            }
+
+            currentChunk = nextChunk
+            currentChunkOffset = 0
+        }
+    }
+
+    fun flush() = Unit
+
+    override fun close() {
+        if (closed) {
+            return
+        }
+        closed = true
+        incomingChunks.offer(ByteArray(0))
+
+        try {
+            readerThread.interrupt()
+        } catch (_: Exception) {
+        }
+
+        resetTransport()
+
+        try {
+            connection.releaseInterface(usbInterface)
+        } catch (_: Exception) {
+        }
+
+        try {
+            connection.close()
+        } catch (_: Exception) {
+        }
+    }
+
+    private fun findAdbInterface(): UsbInterface? {
+        for (index in 0 until usbDevice.interfaceCount) {
+            val usbInterface = usbDevice.getInterface(index)
+            if (UsbConstants.isAdb(usbInterface)) {
+                return usbInterface
+            }
+        }
+        return null
+    }
+
+    private fun findBulkEndpoints(): Pair<UsbEndpoint?, UsbEndpoint?> {
+        var endpointIn: UsbEndpoint? = null
+        var endpointOut: UsbEndpoint? = null
+
+        for (index in 0 until usbInterface.endpointCount) {
+            val endpoint = usbInterface.getEndpoint(index)
+            if (endpoint.type == android.hardware.usb.UsbConstants.USB_ENDPOINT_XFER_BULK) {
+                when (endpoint.direction) {
+                    android.hardware.usb.UsbConstants.USB_DIR_IN -> endpointIn = endpoint
+                    android.hardware.usb.UsbConstants.USB_DIR_OUT -> endpointOut = endpoint
+                }
+            }
+        }
+
+        return endpointIn to endpointOut
+    }
+
+    private fun transferOut(bytes: ByteArray) {
+        var offset = 0
+        while (offset < bytes.size) {
+            val chunkSize = minOf(maxPacketSize, bytes.size - offset)
+            val transferred = connection.bulkTransfer(endpointOut, bytes, offset, chunkSize, writeTimeoutMs)
+            if (transferred < 0) {
+                throw IOException("USB bulk transfer failed: $transferred")
+            }
+            if (transferred == 0) {
+                throw IOException("USB bulk transfer made no progress for ${usbDevice.deviceName}")
+            }
+            offset += transferred
+        }
+    }
+
+    private fun readMessages() {
+        try {
+            while (!closed && !Thread.currentThread().isInterrupted) {
+                val header = readExact(AdbPacketCodec.HEADER_LENGTH)
+                val packetHeader = AdbPacketCodec.parseHeader(header)
+                incomingChunks.put(header)
+                if (packetHeader.payloadLength > 0) {
+                    incomingChunks.put(readExact(packetHeader.payloadLength))
+                }
+            }
+        } catch (t: Throwable) {
+            if (!closed) {
+                readError = t
+            }
+        } finally {
+            incomingChunks.offer(ByteArray(0))
+        }
+    }
+
+    private fun readExact(length: Int): ByteArray {
+        val buffer = ByteArray(length)
+        var offset = 0
+        var lastProgressAt = System.currentTimeMillis()
+
+        while (offset < length) {
+            if (closed || Thread.currentThread().isInterrupted) {
+                throw IOException("USB channel closed while reading: ${usbDevice.deviceName}")
+            }
+
+            val transferred = connection.bulkTransfer(endpointIn, buffer, offset, length - offset, readTimeoutMs)
+            if (transferred <= 0) {
+                val idleMs = System.currentTimeMillis() - lastProgressAt
+                if (readIdleTimeoutMs > 0 && idleMs >= readIdleTimeoutMs) {
+                    throw IOException("USB read timed out waiting for ADB data from ${usbDevice.deviceName}")
+                }
+                continue
+            }
+
+            offset += transferred
+            lastProgressAt = System.currentTimeMillis()
+        }
+
+        return buffer
+    }
+
+    private fun resetTransport() {
+        try {
+            connection.bulkTransfer(endpointOut, ByteArray(100), 100, 100)
+        } catch (_: Exception) {
+        }
+    }
+}

--- a/dadb-android/src/main/kotlin/dadb/android/usb/UsbConstants.kt
+++ b/dadb-android/src/main/kotlin/dadb/android/usb/UsbConstants.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2021 mobile.dev inc.
+ * Android USB transport support by github.com/XRSec/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package dadb.android.usb
+
+import android.hardware.usb.UsbDevice
+import android.hardware.usb.UsbInterface
+
+internal object UsbConstants {
+
+    const val INTERFACE_CLASS = 0xFF
+    const val INTERFACE_SUBCLASS = 0x42
+    const val INTERFACE_PROTOCOL = 0x01
+
+    const val CONNECT_MAX_DATA = 15 * 1024
+    const val MAX_PACKET_SIZE = 16 * 1024
+    const val WRITE_TIMEOUT_MS = 5_000
+    const val READ_TIMEOUT_MS = 1_000
+    // Idle periods are expected once scrcpy sockets/server are torn down but ADB is kept alive.
+    // Real disconnects should be detected by USB detach broadcasts, transport errors, or heartbeat,
+    // not by a short "no inbound packets" timer in the background reader thread.
+    const val READ_IDLE_TIMEOUT_MS = 0
+
+    fun isAdb(device: UsbDevice): Boolean {
+        for (index in 0 until device.interfaceCount) {
+            if (isAdb(device.getInterface(index))) {
+                return true
+            }
+        }
+        return false
+    }
+
+    fun isAdb(usbInterface: UsbInterface): Boolean {
+        return usbInterface.interfaceClass == INTERFACE_CLASS &&
+            usbInterface.interfaceSubclass == INTERFACE_SUBCLASS &&
+            usbInterface.interfaceProtocol == INTERFACE_PROTOCOL
+    }
+}

--- a/dadb-android/src/main/kotlin/dadb/android/usb/UsbTransportFactory.kt
+++ b/dadb-android/src/main/kotlin/dadb/android/usb/UsbTransportFactory.kt
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2021 mobile.dev inc.
+ * Android USB transport support by github.com/XRSec/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package dadb.android.usb
+
+import android.hardware.usb.UsbDevice
+import android.hardware.usb.UsbManager
+import dadb.AdbTransport
+import dadb.AdbTransportFactory
+import dadb.SourceSinkAdbTransport
+import okio.Buffer
+import okio.Sink
+import okio.Source
+import okio.Timeout
+
+/**
+ * Android USB host transport for direct ADB connections.
+ *
+ * This implementation depends on the Android USB host APIs and is not available on
+ * desktop JVM runtimes such as Windows, macOS, or Linux.
+ */
+class UsbTransportFactory(
+    private val usbManager: UsbManager,
+    private val usbDevice: UsbDevice,
+    override val description: String = usbDevice.deviceName,
+    private val connectMaxData: Int = UsbConstants.CONNECT_MAX_DATA,
+    private val maxPacketSize: Int = UsbConstants.MAX_PACKET_SIZE,
+    private val writeTimeoutMs: Int = UsbConstants.WRITE_TIMEOUT_MS,
+    private val readTimeoutMs: Int = UsbConstants.READ_TIMEOUT_MS,
+    private val readIdleTimeoutMs: Int = UsbConstants.READ_IDLE_TIMEOUT_MS,
+) : AdbTransportFactory {
+
+    override fun connect(): AdbTransport {
+        val channel = UsbChannel(
+            usbManager = usbManager,
+            usbDevice = usbDevice,
+            maxPacketSize = maxPacketSize,
+            writeTimeoutMs = writeTimeoutMs,
+            readTimeoutMs = readTimeoutMs,
+            readIdleTimeoutMs = readIdleTimeoutMs,
+        )
+        return SourceSinkAdbTransport(
+            source = UsbSource(channel, maxPacketSize),
+            sink = UsbSink(channel),
+            description = description,
+            connectMaxData = connectMaxData,
+            closeable = channel,
+        )
+    }
+}
+
+private class UsbSource(
+    private val channel: UsbChannel,
+    private val maxPacketSize: Int,
+) : Source {
+
+    override fun read(sink: Buffer, byteCount: Long): Long {
+        if (byteCount == 0L) {
+            return 0L
+        }
+
+        val chunk = channel.readAtMost(minOf(byteCount, maxPacketSize.toLong()).toInt())
+        sink.write(chunk)
+        return chunk.size.toLong()
+    }
+
+    override fun timeout(): Timeout = Timeout.NONE
+
+    override fun close() = Unit
+}
+
+private class UsbSink(
+    private val channel: UsbChannel,
+) : Sink {
+
+    private val pending = Buffer()
+
+    override fun write(source: Buffer, byteCount: Long) {
+        require(byteCount <= Int.MAX_VALUE) { "byteCount too large: $byteCount" }
+        pending.write(source, byteCount)
+        emitCompletePackets()
+    }
+
+    override fun flush() {
+        emitCompletePackets()
+        channel.flush()
+    }
+
+    override fun timeout(): Timeout = Timeout.NONE
+
+    override fun close() = Unit
+
+    private fun emitCompletePackets() {
+        while (true) {
+            val packetLength = AdbPacketCodec.completePacketLength(pending) ?: return
+            if (pending.size < packetLength) {
+                return
+            }
+
+            channel.write(pending.readByteArray(packetLength))
+        }
+    }
+}

--- a/dadb-android/src/main/kotlin/dadb/android/wireless/AdbPairingTypes.kt
+++ b/dadb-android/src/main/kotlin/dadb/android/wireless/AdbPairingTypes.kt
@@ -79,6 +79,12 @@ internal class AdbPairingKey(
                 socket: Socket?,
             ): String = keyAlias
 
+            override fun chooseEngineClientAlias(
+                keyType: Array<out String>?,
+                issuers: Array<out java.security.Principal>?,
+                engine: SSLEngine?,
+            ): String = keyAlias
+
             override fun getCertificateChain(alias: String?): Array<X509Certificate>? =
                 if (alias == keyAlias) arrayOf(certificate) else null
 
@@ -88,7 +94,7 @@ internal class AdbPairingKey(
             override fun getClientAliases(
                 keyType: String?,
                 issuers: Array<out java.security.Principal>?,
-            ): Array<String>? = null
+            ): Array<String> = arrayOf(keyAlias)
 
             override fun getServerAliases(
                 keyType: String?,

--- a/dadb-android/src/main/kotlin/dadb/android/wireless/AdbPairingTypes.kt
+++ b/dadb-android/src/main/kotlin/dadb/android/wireless/AdbPairingTypes.kt
@@ -1,0 +1,204 @@
+package dadb.android.wireless
+
+import dadb.AdbKeyPair
+import org.bouncycastle.asn1.x500.X500Name
+import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo
+import org.bouncycastle.cert.X509v3CertificateBuilder
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder
+import org.conscrypt.Conscrypt
+import java.io.ByteArrayInputStream
+import java.math.BigInteger
+import java.net.Socket
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import java.security.KeyFactory
+import java.security.Provider
+import java.security.SecureRandom
+import java.security.Security
+import java.security.cert.CertificateFactory
+import java.security.cert.X509Certificate
+import java.security.interfaces.RSAPrivateKey
+import java.security.interfaces.RSAPublicKey
+import java.security.spec.RSAPublicKeySpec
+import javax.net.ssl.SSLContext
+import javax.net.ssl.SSLEngine
+import javax.net.ssl.X509ExtendedKeyManager
+import javax.net.ssl.X509ExtendedTrustManager
+
+internal class AdbPairingKey(
+    private val adbKeyPair: AdbKeyPair,
+) {
+    private val keyAlias = adbKeyPair.adbPublicKey().decodeAdbKeyAlias()
+
+    private val rsaPrivateKey: RSAPrivateKey =
+        adbKeyPair.privateKey() as? RSAPrivateKey
+            ?: throw IllegalStateException("Expected RSA private key")
+
+    private val rsaPublicKey: RSAPublicKey by lazy {
+        val keyFactory = KeyFactory.getInstance("RSA")
+        keyFactory.generatePublic(
+            RSAPublicKeySpec(rsaPrivateKey.modulus, BigInteger.valueOf(65537L)),
+        ) as RSAPublicKey
+    }
+
+    private val certificate: X509Certificate by lazy {
+        val signer = JcaContentSignerBuilder("SHA256withRSA").build(rsaPrivateKey)
+        val builder =
+            X509v3CertificateBuilder(
+                X500Name("CN=00"),
+                BigInteger.ONE,
+                java.util.Date(0),
+                java.util.Date(2_461_449_600_000L),
+                X500Name("CN=00"),
+                SubjectPublicKeyInfo.getInstance(rsaPublicKey.encoded),
+            )
+        val encoded = builder.build(signer).encoded
+        CertificateFactory.getInstance("X.509")
+            .generateCertificate(ByteArrayInputStream(encoded)) as X509Certificate
+    }
+
+    val adbPublicKey: ByteArray by lazy { rsaPublicKey.toAdbEncoded(keyAlias) }
+
+    val sslContext: SSLContext by lazy {
+        val conscryptProvider: Provider = Conscrypt.newProviderBuilder().build()
+        if (Security.getProvider(conscryptProvider.name) == null) {
+            Security.insertProviderAt(conscryptProvider, 1)
+        }
+        SSLContext.getInstance("TLSv1.3", conscryptProvider).apply {
+            init(arrayOf(keyManager), arrayOf(trustManager), SecureRandom())
+        }
+    }
+
+    private val keyManager: X509ExtendedKeyManager
+        get() = object : X509ExtendedKeyManager() {
+            private val keyAlias = "adbkey"
+
+            override fun chooseClientAlias(
+                keyType: Array<out String>?,
+                issuers: Array<out java.security.Principal>?,
+                socket: Socket?,
+            ): String = keyAlias
+
+            override fun getCertificateChain(alias: String?): Array<X509Certificate>? =
+                if (alias == keyAlias) arrayOf(certificate) else null
+
+            override fun getPrivateKey(alias: String?) =
+                if (alias == keyAlias) rsaPrivateKey else null
+
+            override fun getClientAliases(
+                keyType: String?,
+                issuers: Array<out java.security.Principal>?,
+            ): Array<String>? = null
+
+            override fun getServerAliases(
+                keyType: String?,
+                issuers: Array<out java.security.Principal>?,
+            ): Array<String>? = null
+
+            override fun chooseServerAlias(
+                keyType: String?,
+                issuers: Array<out java.security.Principal>?,
+                socket: Socket?,
+            ): String? = null
+        }
+
+    @get:Suppress("CustomX509TrustManager", "TrustAllX509TrustManager")
+    private val trustManager: X509ExtendedTrustManager
+        get() = object : X509ExtendedTrustManager() {
+            private fun accept(
+                chain: Array<out X509Certificate>?,
+                authType: String?,
+            ) {
+                if (chain.isNullOrEmpty()) return
+                if (authType.isNullOrBlank()) return
+            }
+
+            override fun checkClientTrusted(
+                chain: Array<out X509Certificate>?,
+                authType: String?,
+                socket: Socket?,
+            ) = accept(chain, authType)
+
+            override fun checkClientTrusted(
+                chain: Array<out X509Certificate>?,
+                authType: String?,
+                engine: SSLEngine?,
+            ) = accept(chain, authType)
+
+            override fun checkClientTrusted(
+                chain: Array<out X509Certificate>?,
+                authType: String?,
+            ) = accept(chain, authType)
+
+            override fun checkServerTrusted(
+                chain: Array<out X509Certificate>?,
+                authType: String?,
+                socket: Socket?,
+            ) = accept(chain, authType)
+
+            override fun checkServerTrusted(
+                chain: Array<out X509Certificate>?,
+                authType: String?,
+                engine: SSLEngine?,
+            ) = accept(chain, authType)
+
+            override fun checkServerTrusted(
+                chain: Array<out X509Certificate>?,
+                authType: String?,
+            ) = accept(chain, authType)
+
+            override fun getAcceptedIssuers(): Array<X509Certificate> = emptyArray()
+        }
+}
+
+private const val ANDROID_PUBKEY_MODULUS_SIZE = 2048 / 8
+private const val ANDROID_PUBKEY_MODULUS_SIZE_WORDS = ANDROID_PUBKEY_MODULUS_SIZE / 4
+private const val RSA_PUBLIC_KEY_SIZE = 524
+private const val DEFAULT_ADB_KEY_ALIAS = "unknown@unknown"
+
+private fun ByteArray.decodeAdbKeyAlias(): String {
+    val text =
+        toString(Charsets.UTF_8)
+            .trimEnd('\u0000')
+            .trim()
+    val separator = text.indexOf(' ')
+    if (separator < 0 || separator == text.lastIndex) {
+        return DEFAULT_ADB_KEY_ALIAS
+    }
+    return text.substring(separator + 1).trim().ifBlank { DEFAULT_ADB_KEY_ALIAS }
+}
+
+private fun BigInteger.toAdbEncodedWords(): IntArray {
+    val encoded = IntArray(ANDROID_PUBKEY_MODULUS_SIZE_WORDS)
+    val r32 = BigInteger.ZERO.setBit(32)
+    var remaining = this
+    for (index in 0 until ANDROID_PUBKEY_MODULUS_SIZE_WORDS) {
+        val parts = remaining.divideAndRemainder(r32)
+        remaining = parts[0]
+        encoded[index] = parts[1].toInt()
+    }
+    return encoded
+}
+
+private fun RSAPublicKey.toAdbEncoded(alias: String): ByteArray {
+    val r32 = BigInteger.ZERO.setBit(32)
+    val n0inv = modulus.remainder(r32).modInverse(r32).negate()
+    val r = BigInteger.ZERO.setBit(ANDROID_PUBKEY_MODULUS_SIZE * 8)
+    val rr = r.modPow(BigInteger.valueOf(2), modulus)
+
+    val buffer = ByteBuffer.allocate(RSA_PUBLIC_KEY_SIZE).order(ByteOrder.LITTLE_ENDIAN)
+    buffer.putInt(ANDROID_PUBKEY_MODULUS_SIZE_WORDS)
+    buffer.putInt(n0inv.toInt())
+    modulus.toAdbEncodedWords().forEach { buffer.putInt(it) }
+    rr.toAdbEncodedWords().forEach { buffer.putInt(it) }
+    buffer.putInt(publicExponent.toInt())
+
+    val base64 = android.util.Base64.encode(buffer.array(), android.util.Base64.NO_WRAP)
+    val suffix = " $alias\u0000".toByteArray(Charsets.UTF_8)
+    return ByteArray(base64.size + suffix.size).also {
+        base64.copyInto(it)
+        suffix.copyInto(it, base64.size)
+    }
+}
+
+class AdbInvalidPairingCodeException : Exception()

--- a/dadb-android/src/main/kotlin/dadb/android/wireless/DirectAdbPairingClient.kt
+++ b/dadb-android/src/main/kotlin/dadb/android/wireless/DirectAdbPairingClient.kt
@@ -1,0 +1,315 @@
+package dadb.android.wireless
+
+import android.util.Log
+import dadb.android.tls.AdbTlsCertificatePins
+import org.conscrypt.Conscrypt
+import java.io.Closeable
+import java.io.DataInputStream
+import java.io.DataOutputStream
+import java.net.Socket
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import java.security.cert.X509Certificate
+import javax.net.ssl.SSLSocket
+
+private const val TAG = "DirectAdbPairing"
+
+private const val CURRENT_KEY_HEADER_VERSION = 1.toByte()
+private const val MIN_SUPPORTED_KEY_HEADER_VERSION = 1.toByte()
+private const val MAX_SUPPORTED_KEY_HEADER_VERSION = 1.toByte()
+private const val MAX_PEER_INFO_SIZE = 8192
+private const val MAX_PAYLOAD_SIZE = MAX_PEER_INFO_SIZE * 2
+
+private const val EXPORTED_KEY_LABEL = "adb-label\u0000"
+private const val EXPORTED_KEY_SIZE = 64
+private const val PAIRING_PACKET_HEADER_SIZE = 6
+
+private class PeerInfo(
+    val type: Byte,
+    rawData: ByteArray,
+) {
+    val data = ByteArray(MAX_PEER_INFO_SIZE - 1)
+
+    init {
+        rawData.copyInto(data, endIndex = rawData.size.coerceAtMost(MAX_PEER_INFO_SIZE - 1))
+    }
+
+    fun writeTo(buffer: ByteBuffer) {
+        buffer.put(type)
+        buffer.put(data)
+    }
+
+    companion object {
+        const val ADB_RSA_PUB_KEY: Byte = 0
+
+        fun readFrom(buffer: ByteBuffer): PeerInfo {
+            val type = buffer.get()
+            val data = ByteArray(MAX_PEER_INFO_SIZE - 1)
+            buffer.get(data)
+            return PeerInfo(type, data)
+        }
+    }
+}
+
+private class PairingPacketHeader(
+    val version: Byte,
+    val type: Byte,
+    val payload: Int,
+) {
+    object Type {
+        const val SPAKE2_MSG: Byte = 0
+        const val PEER_INFO: Byte = 1
+    }
+
+    fun writeTo(buffer: ByteBuffer) {
+        buffer.put(version)
+        buffer.put(type)
+        buffer.putInt(payload)
+    }
+
+    companion object {
+        fun readFrom(buffer: ByteBuffer): PairingPacketHeader? {
+            val version = buffer.get()
+            val type = buffer.get()
+            val payload = buffer.int
+
+            if (version !in MIN_SUPPORTED_KEY_HEADER_VERSION..MAX_SUPPORTED_KEY_HEADER_VERSION) {
+                Log.e(TAG, "header version mismatch: $version")
+                return null
+            }
+            if (type != Type.SPAKE2_MSG && type != Type.PEER_INFO) {
+                Log.e(TAG, "unknown packet type: $type")
+                return null
+            }
+            if (payload !in 1..MAX_PAYLOAD_SIZE) {
+                Log.e(TAG, "unsafe payload size: $payload")
+                return null
+            }
+            return PairingPacketHeader(version, type, payload)
+        }
+    }
+}
+
+internal class PairingContext private constructor(
+    private val nativePtr: Long,
+) {
+    val msg: ByteArray = nativeMsg(nativePtr)
+
+    fun initCipher(theirMsg: ByteArray): Boolean = nativeInitCipher(nativePtr, theirMsg)
+
+    fun encrypt(input: ByteArray): ByteArray? = nativeEncrypt(nativePtr, input)
+
+    fun decrypt(input: ByteArray): ByteArray? = nativeDecrypt(nativePtr, input)
+
+    fun destroy() {
+        nativeDestroy(nativePtr)
+    }
+
+    private external fun nativeMsg(nativePtr: Long): ByteArray
+
+    private external fun nativeInitCipher(
+        nativePtr: Long,
+        theirMsg: ByteArray,
+    ): Boolean
+
+    private external fun nativeEncrypt(
+        nativePtr: Long,
+        input: ByteArray,
+    ): ByteArray?
+
+    private external fun nativeDecrypt(
+        nativePtr: Long,
+        input: ByteArray,
+    ): ByteArray?
+
+    private external fun nativeDestroy(nativePtr: Long)
+
+    companion object {
+        init {
+            System.loadLibrary("adbpairing")
+        }
+
+        fun create(password: ByteArray): PairingContext? {
+            val ptr = nativeConstructor(true, password)
+            return if (ptr != 0L) PairingContext(ptr) else null
+        }
+
+        @JvmStatic
+        private external fun nativeConstructor(
+            isClient: Boolean,
+            password: ByteArray,
+        ): Long
+    }
+}
+
+internal class DirectAdbPairingClient(
+    private val host: String,
+    private val port: Int,
+    private val pairingCode: String,
+    private val key: AdbPairingKey,
+) : Closeable {
+    private enum class State {
+        READY,
+        EXCHANGING_MSGS,
+        EXCHANGING_PEER_INFO,
+        STOPPED,
+    }
+
+    private lateinit var socket: Socket
+    private lateinit var inputStream: DataInputStream
+    private lateinit var outputStream: DataOutputStream
+
+    private val peerInfo = PeerInfo(PeerInfo.ADB_RSA_PUB_KEY, key.adbPublicKey)
+    private lateinit var pairingContext: PairingContext
+    private var state: State = State.READY
+    private var pairingTlsPublicKeySha256Base64: String? = null
+
+    fun start(): PairingSessionMetadata? {
+        setupTlsConnection()
+        state = State.EXCHANGING_MSGS
+        if (!doExchangeMsgs()) {
+            state = State.STOPPED
+            return null
+        }
+
+        state = State.EXCHANGING_PEER_INFO
+        val peerMetadata = doExchangePeerInfo()
+        if (peerMetadata == null) {
+            state = State.STOPPED
+            return null
+        }
+
+        state = State.STOPPED
+        return PairingSessionMetadata(
+            peerAdbPublicKey = peerMetadata.adbPublicKey,
+            pairingTlsPublicKeySha256Base64 = pairingTlsPublicKeySha256Base64,
+        )
+    }
+
+    private fun setupTlsConnection() {
+        socket = Socket(host, port)
+        socket.tcpNoDelay = true
+
+        val tlsSocket =
+            key.sslContext.socketFactory.createSocket(socket, host, port, true) as SSLSocket
+        tlsSocket.startHandshake()
+        pairingTlsPublicKeySha256Base64 = tlsSocket.peerLeafCertificate()?.let(AdbTlsCertificatePins::publicKeySha256Base64)
+
+        inputStream = DataInputStream(tlsSocket.inputStream)
+        outputStream = DataOutputStream(tlsSocket.outputStream)
+
+        val codeBytes = pairingCode.toByteArray(Charsets.UTF_8)
+        val keyMaterial = exportTlsKeyingMaterial(tlsSocket)
+        val password = ByteArray(codeBytes.size + keyMaterial.size)
+        codeBytes.copyInto(password)
+        keyMaterial.copyInto(password, destinationOffset = codeBytes.size)
+
+        pairingContext =
+            checkNotNull(PairingContext.create(password)) {
+                "Unable to create pairing context"
+            }
+    }
+
+    private fun exportTlsKeyingMaterial(sslSocket: SSLSocket): ByteArray {
+        if (Conscrypt.isConscrypt(sslSocket)) {
+            return Conscrypt.exportKeyingMaterial(
+                sslSocket,
+                EXPORTED_KEY_LABEL,
+                null,
+                EXPORTED_KEY_SIZE,
+            )
+        }
+
+        throw IllegalStateException(
+            "TLS socket is not backed by bundled Conscrypt: ${sslSocket.javaClass.name}",
+        )
+    }
+
+    private fun createHeader(
+        type: Byte,
+        payloadSize: Int,
+    ): PairingPacketHeader = PairingPacketHeader(CURRENT_KEY_HEADER_VERSION, type, payloadSize)
+
+    private fun readHeader(): PairingPacketHeader? {
+        val bytes = ByteArray(PAIRING_PACKET_HEADER_SIZE)
+        inputStream.readFully(bytes)
+        val buffer = ByteBuffer.wrap(bytes).order(ByteOrder.BIG_ENDIAN)
+        return PairingPacketHeader.readFrom(buffer)
+    }
+
+    private fun writeHeader(
+        header: PairingPacketHeader,
+        payload: ByteArray,
+    ) {
+        val buffer = ByteBuffer.allocate(PAIRING_PACKET_HEADER_SIZE).order(ByteOrder.BIG_ENDIAN)
+        header.writeTo(buffer)
+        outputStream.write(buffer.array())
+        outputStream.write(payload)
+    }
+
+    private fun doExchangeMsgs(): Boolean {
+        val msg = pairingContext.msg
+        writeHeader(createHeader(PairingPacketHeader.Type.SPAKE2_MSG, msg.size), msg)
+
+        val theirHeader = readHeader() ?: return false
+        if (theirHeader.type != PairingPacketHeader.Type.SPAKE2_MSG) return false
+
+        val theirMessage = ByteArray(theirHeader.payload)
+        inputStream.readFully(theirMessage)
+        return pairingContext.initCipher(theirMessage)
+    }
+
+    private fun doExchangePeerInfo(): PairingPeerMetadata? {
+        val plain = ByteBuffer.allocate(MAX_PEER_INFO_SIZE).order(ByteOrder.BIG_ENDIAN)
+        peerInfo.writeTo(plain)
+
+        val encrypted = pairingContext.encrypt(plain.array()) ?: return null
+        writeHeader(createHeader(PairingPacketHeader.Type.PEER_INFO, encrypted.size), encrypted)
+
+        val theirHeader = readHeader() ?: return null
+        if (theirHeader.type != PairingPacketHeader.Type.PEER_INFO) return null
+
+        val peerMessage = ByteArray(theirHeader.payload)
+        inputStream.readFully(peerMessage)
+
+        val decrypted =
+            pairingContext.decrypt(peerMessage) ?: throw AdbInvalidPairingCodeException()
+        if (decrypted.size != MAX_PEER_INFO_SIZE) {
+            Log.e(TAG, "invalid peer info size: ${decrypted.size}")
+            return null
+        }
+        val remotePeerInfo = PeerInfo.readFrom(ByteBuffer.wrap(decrypted).order(ByteOrder.BIG_ENDIAN))
+        return PairingPeerMetadata(
+            adbPublicKey = remotePeerInfo.data.copyUntilZeroByte(),
+        )
+    }
+
+    override fun close() {
+        runCatching { inputStream.close() }
+        runCatching { outputStream.close() }
+        runCatching { socket.close() }
+        if (state != State.READY) {
+            runCatching { pairingContext.destroy() }
+        }
+    }
+
+    private fun SSLSocket.peerLeafCertificate(): X509Certificate? =
+        session.peerCertificates.firstOrNull() as? X509Certificate
+
+    private fun ByteArray.copyUntilZeroByte(): ByteArray {
+        var end = indexOf(0)
+        if (end < 0) {
+            end = size
+        }
+        return copyOf(end)
+    }
+}
+
+internal data class PairingSessionMetadata(
+    val peerAdbPublicKey: ByteArray,
+    val pairingTlsPublicKeySha256Base64: String?,
+)
+
+private data class PairingPeerMetadata(
+    val adbPublicKey: ByteArray,
+)

--- a/dadb-android/src/main/kotlin/dadb/android/wireless/DirectAdbPairingClient.kt
+++ b/dadb-android/src/main/kotlin/dadb/android/wireless/DirectAdbPairingClient.kt
@@ -2,6 +2,8 @@ package dadb.android.wireless
 
 import android.util.Log
 import dadb.android.tls.AdbTlsCertificatePins
+import dadb.android.tls.AdbTlsErrorMapper
+import dadb.android.tls.AdbTlsSockets
 import org.conscrypt.Conscrypt
 import java.io.Closeable
 import java.io.DataInputStream
@@ -192,7 +194,13 @@ internal class DirectAdbPairingClient(
 
         val tlsSocket =
             key.sslContext.socketFactory.createSocket(socket, host, port, true) as SSLSocket
-        tlsSocket.startHandshake()
+        try {
+            AdbTlsSockets.configureClientSocket(tlsSocket, socket.soTimeout)
+            tlsSocket.startHandshake()
+        } catch (t: Throwable) {
+            runCatching { tlsSocket.close() }
+            throw AdbTlsErrorMapper.map(t)
+        }
         pairingTlsPublicKeySha256Base64 = tlsSocket.peerLeafCertificate()?.let(AdbTlsCertificatePins::publicKeySha256Base64)
 
         inputStream = DataInputStream(tlsSocket.inputStream)

--- a/dadb-android/src/main/kotlin/dadb/android/wireless/DirectAdbPairingClient.kt
+++ b/dadb-android/src/main/kotlin/dadb/android/wireless/DirectAdbPairingClient.kt
@@ -16,17 +16,17 @@ import javax.net.ssl.SSLSocket
 
 private const val TAG = "DirectAdbPairing"
 
-private const val CURRENT_KEY_HEADER_VERSION = 1.toByte()
-private const val MIN_SUPPORTED_KEY_HEADER_VERSION = 1.toByte()
-private const val MAX_SUPPORTED_KEY_HEADER_VERSION = 1.toByte()
-private const val MAX_PEER_INFO_SIZE = 8192
-private const val MAX_PAYLOAD_SIZE = MAX_PEER_INFO_SIZE * 2
+internal const val CURRENT_KEY_HEADER_VERSION = 1.toByte()
+internal const val MIN_SUPPORTED_KEY_HEADER_VERSION = 1.toByte()
+internal const val MAX_SUPPORTED_KEY_HEADER_VERSION = 1.toByte()
+internal const val MAX_PEER_INFO_SIZE = 8192
+internal const val MAX_PAYLOAD_SIZE = MAX_PEER_INFO_SIZE * 2
 
-private const val EXPORTED_KEY_LABEL = "adb-label\u0000"
-private const val EXPORTED_KEY_SIZE = 64
-private const val PAIRING_PACKET_HEADER_SIZE = 6
+internal const val EXPORTED_KEY_LABEL = "adb-label\u0000"
+internal const val EXPORTED_KEY_SIZE = 64
+internal const val PAIRING_PACKET_HEADER_SIZE = 6
 
-private class PeerInfo(
+internal class PairingPeerInfo(
     val type: Byte,
     rawData: ByteArray,
 ) {
@@ -44,16 +44,16 @@ private class PeerInfo(
     companion object {
         const val ADB_RSA_PUB_KEY: Byte = 0
 
-        fun readFrom(buffer: ByteBuffer): PeerInfo {
+        fun readFrom(buffer: ByteBuffer): PairingPeerInfo {
             val type = buffer.get()
             val data = ByteArray(MAX_PEER_INFO_SIZE - 1)
             buffer.get(data)
-            return PeerInfo(type, data)
+            return PairingPeerInfo(type, data)
         }
     }
 }
 
-private class PairingPacketHeader(
+internal class PairingPacketHeader(
     val version: Byte,
     val type: Byte,
     val payload: Int,
@@ -70,26 +70,84 @@ private class PairingPacketHeader(
     }
 
     companion object {
-        fun readFrom(buffer: ByteBuffer): PairingPacketHeader? {
+        fun readFrom(
+            buffer: ByteBuffer,
+            logError: (String) -> Unit = { Log.e(TAG, it) },
+        ): PairingPacketHeader? {
             val version = buffer.get()
             val type = buffer.get()
             val payload = buffer.int
 
             if (version !in MIN_SUPPORTED_KEY_HEADER_VERSION..MAX_SUPPORTED_KEY_HEADER_VERSION) {
-                Log.e(TAG, "header version mismatch: $version")
+                logError("header version mismatch: $version")
                 return null
             }
             if (type != Type.SPAKE2_MSG && type != Type.PEER_INFO) {
-                Log.e(TAG, "unknown packet type: $type")
+                logError("unknown packet type: $type")
                 return null
             }
             if (payload !in 1..MAX_PAYLOAD_SIZE) {
-                Log.e(TAG, "unsafe payload size: $payload")
+                logError("unsafe payload size: $payload")
                 return null
             }
             return PairingPacketHeader(version, type, payload)
         }
     }
+}
+
+internal enum class PairingClientState {
+    READY,
+    EXCHANGING_MSGS,
+    EXCHANGING_PEER_INFO,
+    STOPPED,
+}
+
+internal object PairingClientStateMachine {
+    fun start(state: PairingClientState): PairingClientState {
+        check(state == PairingClientState.READY) { "Pairing client can only start from READY, was $state" }
+        return PairingClientState.EXCHANGING_MSGS
+    }
+
+    fun afterMessageExchange(
+        state: PairingClientState,
+        success: Boolean,
+    ): PairingClientState {
+        check(state == PairingClientState.EXCHANGING_MSGS) {
+            "Message exchange can only complete from EXCHANGING_MSGS, was $state"
+        }
+        return if (success) PairingClientState.EXCHANGING_PEER_INFO else PairingClientState.STOPPED
+    }
+
+    fun afterPeerInfoExchange(
+        state: PairingClientState,
+        success: Boolean,
+    ): PairingClientState {
+        check(state == PairingClientState.EXCHANGING_PEER_INFO) {
+            "Peer info exchange can only complete from EXCHANGING_PEER_INFO, was $state"
+        }
+        return PairingClientState.STOPPED
+    }
+}
+
+internal fun decodePeerAdbPublicKey(
+    decrypted: ByteArray?,
+    onInvalidSize: (Int) -> Unit = {},
+): ByteArray? {
+    val payload = decrypted ?: throw AdbInvalidPairingCodeException()
+    if (payload.size != MAX_PEER_INFO_SIZE) {
+        onInvalidSize(payload.size)
+        return null
+    }
+    val remotePeerInfo = PairingPeerInfo.readFrom(ByteBuffer.wrap(payload).order(ByteOrder.BIG_ENDIAN))
+    return remotePeerInfo.data.copyUntilZeroByte()
+}
+
+internal fun ByteArray.copyUntilZeroByte(): ByteArray {
+    var end = indexOf(0)
+    if (end < 0) {
+        end = size
+    }
+    return copyOf(end)
 }
 
 internal class PairingContext private constructor(
@@ -150,38 +208,30 @@ internal class DirectAdbPairingClient(
     private val pairingCode: String,
     private val key: AdbPairingKey,
 ) : Closeable {
-    private enum class State {
-        READY,
-        EXCHANGING_MSGS,
-        EXCHANGING_PEER_INFO,
-        STOPPED,
-    }
-
     private lateinit var socket: Socket
     private lateinit var inputStream: DataInputStream
     private lateinit var outputStream: DataOutputStream
 
-    private val peerInfo = PeerInfo(PeerInfo.ADB_RSA_PUB_KEY, key.adbPublicKey)
+    private val peerInfo = PairingPeerInfo(PairingPeerInfo.ADB_RSA_PUB_KEY, key.adbPublicKey)
     private lateinit var pairingContext: PairingContext
-    private var state: State = State.READY
+    private var state: PairingClientState = PairingClientState.READY
     private var pairingTlsPublicKeySha256Base64: String? = null
 
     fun start(): PairingSessionMetadata? {
         setupTlsConnection()
-        state = State.EXCHANGING_MSGS
-        if (!doExchangeMsgs()) {
-            state = State.STOPPED
+        state = PairingClientStateMachine.start(state)
+        val exchangedMsgs = doExchangeMsgs()
+        state = PairingClientStateMachine.afterMessageExchange(state, exchangedMsgs)
+        if (!exchangedMsgs) {
             return null
         }
 
-        state = State.EXCHANGING_PEER_INFO
         val peerMetadata = doExchangePeerInfo()
+        state = PairingClientStateMachine.afterPeerInfoExchange(state, peerMetadata != null)
         if (peerMetadata == null) {
-            state = State.STOPPED
             return null
         }
 
-        state = State.STOPPED
         return PairingSessionMetadata(
             peerAdbPublicKey = peerMetadata.adbPublicKey,
             pairingTlsPublicKeySha256Base64 = pairingTlsPublicKeySha256Base64,
@@ -280,15 +330,13 @@ internal class DirectAdbPairingClient(
         val peerMessage = ByteArray(theirHeader.payload)
         inputStream.readFully(peerMessage)
 
-        val decrypted =
-            pairingContext.decrypt(peerMessage) ?: throw AdbInvalidPairingCodeException()
-        if (decrypted.size != MAX_PEER_INFO_SIZE) {
-            Log.e(TAG, "invalid peer info size: ${decrypted.size}")
-            return null
-        }
-        val remotePeerInfo = PeerInfo.readFrom(ByteBuffer.wrap(decrypted).order(ByteOrder.BIG_ENDIAN))
+        val adbPublicKey =
+            decodePeerAdbPublicKey(
+                decrypted = pairingContext.decrypt(peerMessage),
+                onInvalidSize = { size -> Log.e(TAG, "invalid peer info size: $size") },
+            ) ?: return null
         return PairingPeerMetadata(
-            adbPublicKey = remotePeerInfo.data.copyUntilZeroByte(),
+            adbPublicKey = adbPublicKey,
         )
     }
 
@@ -296,22 +344,14 @@ internal class DirectAdbPairingClient(
         runCatching { inputStream.close() }
         runCatching { outputStream.close() }
         runCatching { socket.close() }
-        if (state != State.READY) {
+        if (state != PairingClientState.READY) {
             runCatching { pairingContext.destroy() }
         }
     }
-
-    private fun SSLSocket.peerLeafCertificate(): X509Certificate? =
-        session.peerCertificates.firstOrNull() as? X509Certificate
-
-    private fun ByteArray.copyUntilZeroByte(): ByteArray {
-        var end = indexOf(0)
-        if (end < 0) {
-            end = size
-        }
-        return copyOf(end)
-    }
 }
+
+private fun SSLSocket.peerLeafCertificate(): X509Certificate? =
+    session.peerCertificates.firstOrNull() as? X509Certificate
 
 internal data class PairingSessionMetadata(
     val peerAdbPublicKey: ByteArray,

--- a/dadb-android/src/main/kotlin/dadb/android/wireless/WirelessDebugPairing.kt
+++ b/dadb-android/src/main/kotlin/dadb/android/wireless/WirelessDebugPairing.kt
@@ -1,0 +1,40 @@
+package dadb.android.wireless
+
+import dadb.AdbKeyPair
+
+data class WirelessDebugPairingRequest(
+    val host: String,
+    val port: Int,
+    val pairingCode: String,
+)
+
+data class WirelessDebugPairingResult(
+    val host: String,
+    val port: Int,
+    val peerAdbPublicKey: ByteArray,
+    val pairingTlsPublicKeySha256Base64: String?,
+)
+
+class WirelessDebugPairingClient(
+    private val keyPair: AdbKeyPair,
+) {
+    fun pair(request: WirelessDebugPairingRequest): Result<WirelessDebugPairingResult> =
+        runCatching {
+            val session =
+                DirectAdbPairingClient(
+                    host = request.host,
+                    port = request.port,
+                    pairingCode = request.pairingCode,
+                    key = AdbPairingKey(keyPair),
+                ).use { client ->
+                    client.start()
+                } ?: throw IllegalStateException("Wireless Debugging pairing failed")
+
+            WirelessDebugPairingResult(
+                host = request.host,
+                port = request.port,
+                peerAdbPublicKey = session.peerAdbPublicKey,
+                pairingTlsPublicKeySha256Base64 = session.pairingTlsPublicKeySha256Base64,
+            )
+        }
+}

--- a/dadb-android/src/test/kotlin/dadb/android/runtime/AdbRuntimeTest.kt
+++ b/dadb-android/src/test/kotlin/dadb/android/runtime/AdbRuntimeTest.kt
@@ -86,4 +86,24 @@ class AdbRuntimeTest {
             targetRoot.deleteRecursively()
         }
     }
+
+    @Test
+    fun loadOrCreateKeyPair_usesConfiguredIdentityLabel() {
+        val rootDir = Files.createTempDirectory("adb-runtime-test").toFile()
+        try {
+            val runtime =
+                AdbRuntime(
+                    rootDir,
+                    AdbRuntimeOptions(identityLabel = "Pixel8@ScreenRemote"),
+                )
+
+            runtime.loadOrCreateKeyPair()
+
+            val identity = runtime.readIdentity()
+
+            assertTrue(identity.publicKey.orEmpty().contains("Pixel8@ScreenRemote"))
+        } finally {
+            rootDir.deleteRecursively()
+        }
+    }
 }

--- a/dadb-android/src/test/kotlin/dadb/android/runtime/AdbRuntimeTest.kt
+++ b/dadb-android/src/test/kotlin/dadb/android/runtime/AdbRuntimeTest.kt
@@ -1,0 +1,89 @@
+package dadb.android.runtime
+
+import java.nio.file.Files
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+@OptIn(ExperimentalDadbAndroidApi::class)
+class AdbRuntimeTest {
+    @Test
+    fun readIdentity_returnsStoredPublicKey() {
+        val rootDir = Files.createTempDirectory("adb-runtime-test").toFile()
+        try {
+            val runtime = AdbRuntime(rootDir)
+
+            runtime.loadOrCreateKeyPair()
+
+            val identity = runtime.readIdentity()
+
+            assertNotNull(identity.publicKey)
+        } finally {
+            rootDir.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun regenerateKeyPair_refreshesIdentityFiles() {
+        val rootDir = Files.createTempDirectory("adb-runtime-test").toFile()
+        try {
+            val runtime = AdbRuntime(rootDir)
+            runtime.loadOrCreateKeyPair()
+
+            val regeneratedKeyPair = runtime.regenerateKeyPair()
+            val identity = runtime.readIdentity()
+
+            assertNotNull(regeneratedKeyPair)
+            assertNotNull(identity.privateKey)
+            assertNotNull(identity.publicKey)
+        } finally {
+            rootDir.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun replaceKeyPair_preservesIdentity_whenInputMatchesExistingKeyPair() {
+        val rootDir = Files.createTempDirectory("adb-runtime-test").toFile()
+        try {
+            val runtime = AdbRuntime(rootDir)
+            runtime.loadOrCreateKeyPair()
+            val identity = runtime.readIdentity()
+
+            runtime.replaceKeyPair(
+                privateKey = identity.privateKey.orEmpty(),
+                publicKey = identity.publicKey.orEmpty(),
+            )
+
+            assertEquals(identity.privateKey, runtime.readIdentity().privateKey)
+            assertEquals(identity.publicKey, runtime.readIdentity().publicKey)
+        } finally {
+            rootDir.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun replaceKeyPair_roundTripsIdentityIntoFreshRuntime() {
+        val sourceRoot = Files.createTempDirectory("adb-runtime-source").toFile()
+        val targetRoot = Files.createTempDirectory("adb-runtime-target").toFile()
+        try {
+            val sourceRuntime = AdbRuntime(sourceRoot)
+            sourceRuntime.loadOrCreateKeyPair()
+            val sourceIdentity = sourceRuntime.readIdentity()
+
+            val targetRuntime = AdbRuntime(targetRoot)
+            val restoredKeyPair =
+                targetRuntime.replaceKeyPair(
+                    privateKey = sourceIdentity.privateKey.orEmpty(),
+                    publicKey = sourceIdentity.publicKey.orEmpty(),
+                )
+
+            assertNotNull(restoredKeyPair)
+            assertEquals(sourceIdentity.privateKey, targetRuntime.readIdentity().privateKey)
+            assertEquals(sourceIdentity.publicKey, targetRuntime.readIdentity().publicKey)
+        } finally {
+            sourceRoot.deleteRecursively()
+            targetRoot.deleteRecursively()
+        }
+    }
+}

--- a/dadb-android/src/test/kotlin/dadb/android/runtime/AdbRuntimeTransportTest.kt
+++ b/dadb-android/src/test/kotlin/dadb/android/runtime/AdbRuntimeTransportTest.kt
@@ -1,0 +1,425 @@
+package dadb.android.runtime
+
+import dadb.AdbKeyPair
+import dadb.android.tls.AdbTlsCertificatePins
+import java.io.ByteArrayInputStream
+import java.io.InputStream
+import java.io.OutputStream
+import java.math.BigInteger
+import java.net.ServerSocket
+import java.net.SocketTimeoutException
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import java.security.KeyFactory
+import java.security.KeyPairGenerator
+import java.security.PrivateKey
+import java.security.SecureRandom
+import java.security.cert.CertificateFactory
+import java.security.cert.X509Certificate
+import java.security.interfaces.RSAPrivateKey
+import java.security.interfaces.RSAPublicKey
+import java.security.spec.RSAPublicKeySpec
+import java.nio.file.Files
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+import javax.net.ssl.SSLContext
+import javax.net.ssl.SSLEngine
+import javax.net.ssl.SSLSocket
+import javax.net.ssl.X509ExtendedKeyManager
+import javax.net.ssl.X509ExtendedTrustManager
+import kotlin.concurrent.thread
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.bouncycastle.asn1.x500.X500Name
+import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo
+import org.bouncycastle.cert.X509v3CertificateBuilder
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder
+
+@OptIn(ExperimentalDadbAndroidApi::class)
+class AdbRuntimeTransportTest {
+    @Test
+    fun plainAdbServer_usesTcpTransportMode() {
+        val rootDir = Files.createTempDirectory("adb-runtime-transport-test").toFile()
+        PlainAdbServer().use { server ->
+            try {
+                val runtime = AdbRuntime(rootDir)
+                val connection =
+                    runtime.connectNetworkDadb(
+                        host = LOCALHOST,
+                        port = server.port,
+                        connectTimeout = 1_000,
+                        socketTimeout = 1_000,
+                    )
+
+                connection.use {
+                    assertEquals(false, connection.isTlsConnection())
+                }
+                server.awaitHandledConnection()
+            } finally {
+                rootDir.deleteRecursively()
+            }
+        }
+    }
+
+    @Test
+    fun tlsConnect_reportsObservedPinsAcrossConnections() {
+        val rootDir = Files.createTempDirectory("adb-runtime-transport-test").toFile()
+        try {
+            val observedPeers = mutableListOf<AdbTlsPeerIdentity>()
+            val runtime =
+                AdbRuntime(
+                    rootDir,
+                    AdbRuntimeOptions(
+                        onServerTlsPeerObserved = observedPeers::add,
+                    ),
+                )
+            runtime.loadOrCreateKeyPair()
+
+            val firstServer = UpgradedTlsAdbServer()
+            val firstConnectPin = firstServer.connectPin
+            firstServer.use { server ->
+                val firstConnection =
+                    runtime.connectNetworkDadb(
+                        host = LOCALHOST,
+                        port = server.port,
+                        connectTimeout = 1_000,
+                        socketTimeout = 1_000,
+                    )
+                firstConnection.use {
+                    assertEquals(true, firstConnection.isTlsConnection())
+                }
+                server.awaitHandledConnection()
+            }
+
+            UpgradedTlsAdbServer(allowClientAbort = true).use { mismatchedServer ->
+                val secondConnection =
+                    runtime.connectNetworkDadb(
+                        host = LOCALHOST,
+                        port = mismatchedServer.port,
+                        connectTimeout = 1_000,
+                        socketTimeout = 1_000,
+                    )
+                secondConnection.use {
+                    assertEquals(true, secondConnection.isTlsConnection())
+                }
+                mismatchedServer.awaitHandledConnection()
+            }
+
+            assertEquals(2, observedPeers.size)
+            assertEquals(LOCALHOST, observedPeers.first().target.host)
+            assertEquals(firstServer.port, observedPeers.first().target.port)
+            assertEquals(firstConnectPin, observedPeers.first().observedPinSha256Base64)
+            assertTrue(observedPeers.last().observedPinSha256Base64.isNotBlank())
+        } finally {
+            rootDir.deleteRecursively()
+        }
+    }
+
+    private class PlainAdbServer : AutoCloseable {
+        private val serverSocket = ServerSocket(0)
+        private val serverError = AtomicReference<Throwable?>()
+        private val connectionHandled = CountDownLatch(1)
+        private val serverThread =
+            thread(start = true, isDaemon = true, name = "plain-adb-server") {
+                try {
+                    serverSocket.accept().use { socket ->
+                        socket.soTimeout = 5_000
+                        val message = readMessageHeader(socket.getInputStream())
+                        check(message.command == CMD_CNXN) { "Expected CNXN, got ${message.command}" }
+                        writeMessage(
+                            output = socket.getOutputStream(),
+                            command = CMD_CNXN,
+                            arg0 = CONNECT_VERSION,
+                            arg1 = 4_096,
+                            payload = "device::features=shell_v2".toByteArray(),
+                        )
+                        connectionHandled.countDown()
+                    }
+                } catch (_: SocketTimeoutException) {
+                    connectionHandled.countDown()
+                } catch (t: Throwable) {
+                    serverError.set(t)
+                    connectionHandled.countDown()
+                } finally {
+                    runCatching { serverSocket.close() }
+                }
+            }
+
+        val port: Int = serverSocket.localPort
+
+        fun awaitHandledConnection() {
+            check(connectionHandled.await(10, TimeUnit.SECONDS)) { "Timed out waiting for plain ADB server" }
+            serverError.get()?.let { throw AssertionError("Plain ADB server failed", it) }
+        }
+
+        override fun close() {
+            runCatching { serverSocket.close() }
+            serverThread.join(5_000)
+        }
+    }
+
+    private class UpgradedTlsAdbServer(
+        private val allowClientAbort: Boolean = false,
+    ) : AutoCloseable {
+        private val serverSocket = ServerSocket(0)
+        private val serverError = AtomicReference<Throwable?>()
+        private val connectionHandled = CountDownLatch(1)
+        private val privateKey = generatePrivateKey()
+        private val certificate = createCertificate(privateKey)
+        val connectPin: String = AdbTlsCertificatePins.publicKeySha256Base64(certificate)
+
+        private val serverThread =
+            thread(start = true, isDaemon = true, name = "tls-adb-server") {
+                try {
+                    serverSocket.accept().use { socket ->
+                        socket.soTimeout = 5_000
+                        val connectMessage = readMessage(socket.getInputStream())
+                        check(connectMessage.command == CMD_CNXN) { "Expected CNXN, got ${connectMessage.command}" }
+                        writeMessage(
+                            output = socket.getOutputStream(),
+                            command = CMD_STLS,
+                            arg0 = CONNECT_VERSION,
+                            arg1 = 0,
+                            payload = byteArrayOf(),
+                        )
+
+                        val stlsMessage = readMessage(socket.getInputStream())
+                        check(stlsMessage.command == CMD_STLS) { "Expected STLS, got ${stlsMessage.command}" }
+
+                        val sslSocket = createServerSslContext().socketFactory.createSocket(socket, LOCALHOST, socket.port, true) as SSLSocket
+                        sslSocket.use { upgradedSocket ->
+                            upgradedSocket.useClientMode = false
+                            upgradedSocket.soTimeout = 5_000
+                            upgradedSocket.startHandshake()
+                            writeMessage(
+                                output = upgradedSocket.getOutputStream(),
+                                command = CMD_CNXN,
+                                arg0 = CONNECT_VERSION,
+                                arg1 = 4_096,
+                                payload = "device::features=shell_v2".toByteArray(),
+                            )
+                            connectionHandled.countDown()
+                        }
+                    }
+                } catch (_: SocketTimeoutException) {
+                    connectionHandled.countDown()
+                } catch (t: java.net.SocketException) {
+                    if (allowClientAbort && t.message.orEmpty().contains("Broken pipe")) {
+                        connectionHandled.countDown()
+                    } else {
+                        serverError.set(t)
+                        connectionHandled.countDown()
+                    }
+                } catch (t: Throwable) {
+                    serverError.set(t)
+                    connectionHandled.countDown()
+                } finally {
+                    runCatching { serverSocket.close() }
+                }
+            }
+
+        val port: Int = serverSocket.localPort
+
+        fun awaitHandledConnection() {
+            check(connectionHandled.await(10, TimeUnit.SECONDS)) { "Timed out waiting for TLS ADB server" }
+            serverError.get()?.let { throw AssertionError("TLS ADB server failed", it) }
+        }
+
+        override fun close() {
+            runCatching { serverSocket.close() }
+            serverThread.join(5_000)
+        }
+
+        private fun createServerSslContext(): SSLContext =
+            SSLContext.getInstance("TLS").apply {
+                init(
+                    arrayOf(createServerKeyManager(privateKey, certificate)),
+                    arrayOf(createInsecureTrustManager()),
+                    SecureRandom(),
+                )
+            }
+    }
+
+    private data class TestAdbMessage(
+        val command: Int,
+        val arg0: Int,
+        val arg1: Int,
+        val payloadLength: Int,
+    )
+
+    private companion object {
+        private const val LOCALHOST = "127.0.0.1"
+        private const val CMD_CNXN = 0x4e584e43
+        private const val CMD_STLS = 0x534c5453
+        private const val CONNECT_VERSION = 0x01000000
+
+        private fun readMessageHeader(input: InputStream): TestAdbMessage {
+            val header = input.readNBytes(24)
+            check(header.size == 24) { "Incomplete ADB header" }
+            val headerBuffer = ByteBuffer.wrap(header).order(ByteOrder.LITTLE_ENDIAN)
+            val command = headerBuffer.int
+            val arg0 = headerBuffer.int
+            val arg1 = headerBuffer.int
+            val payloadLength = headerBuffer.int
+            headerBuffer.int
+            headerBuffer.int
+            return TestAdbMessage(
+                command = command,
+                arg0 = arg0,
+                arg1 = arg1,
+                payloadLength = payloadLength,
+            )
+        }
+
+        private fun readMessage(input: InputStream): TestAdbMessage {
+            val message = readMessageHeader(input)
+            val payload = input.readNBytes(message.payloadLength)
+            check(payload.size == message.payloadLength) { "Incomplete ADB payload" }
+            return message
+        }
+
+        private fun writeMessage(
+            output: OutputStream,
+            command: Int,
+            arg0: Int,
+            arg1: Int,
+            payload: ByteArray,
+        ) {
+            val checksum = payload.fold(0) { sum, byte -> sum + (byte.toInt() and 0xff) }
+            val header =
+                ByteBuffer.allocate(24)
+                    .order(ByteOrder.LITTLE_ENDIAN)
+                    .putInt(command)
+                    .putInt(arg0)
+                    .putInt(arg1)
+                    .putInt(payload.size)
+                    .putInt(checksum)
+                    .putInt(command xor -0x1)
+                    .array()
+
+            output.write(header)
+            output.write(payload)
+            output.flush()
+        }
+
+        private fun generatePrivateKey(): RSAPrivateKey =
+            KeyPairGenerator.getInstance("RSA").apply {
+                initialize(2048)
+            }.generateKeyPair().private as RSAPrivateKey
+
+        private fun createCertificate(privateKey: RSAPrivateKey): X509Certificate {
+            val rsaPublicKey =
+                KeyFactory.getInstance("RSA")
+                    .generatePublic(RSAPublicKeySpec(privateKey.modulus, BigInteger.valueOf(65537L))) as RSAPublicKey
+
+            val signer = JcaContentSignerBuilder("SHA256withRSA").build(privateKey)
+            val builder =
+                X509v3CertificateBuilder(
+                    X500Name("CN=00"),
+                    BigInteger.ONE,
+                    java.util.Date(0),
+                    java.util.Date(2_461_449_600_000L),
+                    X500Name("CN=00"),
+                    SubjectPublicKeyInfo.getInstance(rsaPublicKey.encoded),
+                )
+            val encoded = builder.build(signer).encoded
+
+            return CertificateFactory.getInstance("X.509")
+                .generateCertificate(ByteArrayInputStream(encoded)) as X509Certificate
+        }
+
+        private fun createServerKeyManager(
+            privateKey: PrivateKey,
+            certificate: X509Certificate,
+        ): X509ExtendedKeyManager =
+            object : X509ExtendedKeyManager() {
+                private val keyAlias = "adbkey"
+
+                override fun chooseClientAlias(
+                    keyType: Array<out String>?,
+                    issuers: Array<out java.security.Principal>?,
+                    socket: java.net.Socket?,
+                ): String? = null
+
+                override fun chooseServerAlias(
+                    keyType: String?,
+                    issuers: Array<out java.security.Principal>?,
+                    socket: java.net.Socket?,
+                ): String = keyAlias
+
+                override fun getCertificateChain(alias: String?): Array<X509Certificate>? =
+                    if (alias == keyAlias) {
+                        arrayOf(certificate)
+                    } else {
+                        null
+                    }
+
+                override fun getPrivateKey(alias: String?): PrivateKey? =
+                    if (alias == keyAlias) {
+                        privateKey
+                    } else {
+                        null
+                    }
+
+                override fun getClientAliases(
+                    keyType: String?,
+                    issuers: Array<out java.security.Principal>?,
+                ): Array<String>? = null
+
+                override fun getServerAliases(
+                    keyType: String?,
+                    issuers: Array<out java.security.Principal>?,
+                ): Array<String> = arrayOf(keyAlias)
+            }
+
+        private fun createInsecureTrustManager(): X509ExtendedTrustManager =
+            object : X509ExtendedTrustManager() {
+                private fun accept(
+                    chain: Array<out X509Certificate>?,
+                    authType: String?,
+                ) {
+                    if (chain.isNullOrEmpty()) return
+                    if (authType.isNullOrBlank()) return
+                }
+
+                override fun checkClientTrusted(
+                    chain: Array<out X509Certificate>?,
+                    authType: String?,
+                    socket: java.net.Socket?,
+                ) = accept(chain, authType)
+
+                override fun checkClientTrusted(
+                    chain: Array<out X509Certificate>?,
+                    authType: String?,
+                    engine: SSLEngine?,
+                ) = accept(chain, authType)
+
+                override fun checkClientTrusted(
+                    chain: Array<out X509Certificate>?,
+                    authType: String?,
+                ) = accept(chain, authType)
+
+                override fun checkServerTrusted(
+                    chain: Array<out X509Certificate>?,
+                    authType: String?,
+                    socket: java.net.Socket?,
+                ) = accept(chain, authType)
+
+                override fun checkServerTrusted(
+                    chain: Array<out X509Certificate>?,
+                    authType: String?,
+                    engine: SSLEngine?,
+                ) = accept(chain, authType)
+
+                override fun checkServerTrusted(
+                    chain: Array<out X509Certificate>?,
+                    authType: String?,
+                ) = accept(chain, authType)
+
+                override fun getAcceptedIssuers(): Array<X509Certificate> = emptyArray()
+            }
+    }
+}

--- a/dadb-android/src/test/kotlin/dadb/android/runtime/AdbTlsTrustPolicyTest.kt
+++ b/dadb-android/src/test/kotlin/dadb/android/runtime/AdbTlsTrustPolicyTest.kt
@@ -1,5 +1,7 @@
 package dadb.android.runtime
 
+import dadb.android.tls.AdbTlsCertificatePins
+import dadb.android.tls.AdbTlsPinMismatchException
 import java.math.BigInteger
 import java.security.KeyPairGenerator
 import java.security.Principal
@@ -8,6 +10,7 @@ import java.security.cert.CertificateEncodingException
 import java.security.cert.X509Certificate
 import java.util.Date
 import javax.net.ssl.X509ExtendedTrustManager
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertSame
 import org.junit.Test
 
@@ -74,6 +77,40 @@ class AdbTlsTrustPolicyTest {
                 .resolveTrustManager(target = AdbNetworkEndpoint(host = "192.168.0.10", port = 37099))
 
         assertSame(customTrustManager, trustManager)
+    }
+
+    @Test
+    fun pinned_policy_acceptsMatchingPin() {
+        val certificate = fakeCertificate(generatePublicKey())
+        val expectedPin = AdbTlsCertificatePins.publicKeySha256Base64(certificate)
+        val trustManager =
+            AdbTlsTrustPolicy.Pinned(expectedPin)
+                .resolveTrustManager(target = AdbNetworkEndpoint(host = "192.168.0.10", port = 37099))
+
+        trustManager.checkServerTrusted(arrayOf(certificate), "RSA")
+    }
+
+    @Test
+    fun pinned_policy_rejectsMismatchedPin() {
+        val certificate = fakeCertificate(generatePublicKey())
+        val trustManager =
+            AdbTlsTrustPolicy.Pinned("expected-pin")
+                .resolveTrustManager(target = AdbNetworkEndpoint(host = "192.168.0.10", port = 37099))
+
+        val error =
+            try {
+                trustManager.checkServerTrusted(arrayOf(certificate), "RSA")
+                null
+            } catch (t: AdbTlsPinMismatchException) {
+                t
+            }
+
+        requireNotNull(error)
+        assertEquals("expected-pin", error.expectedPinSha256Base64)
+        assertEquals(
+            AdbTlsCertificatePins.publicKeySha256Base64(certificate),
+            error.observedPinSha256Base64,
+        )
     }
 
     private fun generatePublicKey(): PublicKey =

--- a/dadb-android/src/test/kotlin/dadb/android/runtime/AdbTlsTrustPolicyTest.kt
+++ b/dadb-android/src/test/kotlin/dadb/android/runtime/AdbTlsTrustPolicyTest.kt
@@ -1,0 +1,138 @@
+package dadb.android.runtime
+
+import java.math.BigInteger
+import java.security.KeyPairGenerator
+import java.security.Principal
+import java.security.PublicKey
+import java.security.cert.CertificateEncodingException
+import java.security.cert.X509Certificate
+import java.util.Date
+import javax.net.ssl.X509ExtendedTrustManager
+import org.junit.Assert.assertSame
+import org.junit.Test
+
+@OptIn(ExperimentalDadbAndroidApi::class)
+class AdbTlsTrustPolicyTest {
+    @Test
+    fun trustAll_acceptsServerCertificate() {
+        val trustManager =
+            AdbTlsTrustPolicy.TrustAll.resolveTrustManager(
+                target = AdbNetworkEndpoint(host = "192.168.0.10", port = 37099),
+            )
+
+        trustManager.checkServerTrusted(arrayOf(fakeCertificate(generatePublicKey())), "RSA")
+    }
+
+    @Test
+    fun trustAll_acceptsAnyServerCertificateShape() {
+        val trustManager =
+            AdbTlsTrustPolicy.TrustAll.resolveTrustManager(
+                target = AdbNetworkEndpoint(host = "192.168.0.10", port = 37099),
+            )
+
+        trustManager.checkServerTrusted(arrayOf(fakeCertificate(generatePublicKey())), "RSA")
+        trustManager.checkServerTrusted(emptyArray(), "RSA")
+        trustManager.checkServerTrusted(arrayOf(fakeCertificate(generatePublicKey())), null)
+    }
+
+    @Test
+    fun custom_policy_usesProvidedTrustManagerFactory() {
+        val customTrustManager = object : X509ExtendedTrustManager() {
+            override fun checkClientTrusted(chain: Array<out X509Certificate>?, authType: String?) = Unit
+
+            override fun checkClientTrusted(
+                chain: Array<out X509Certificate>?,
+                authType: String?,
+                socket: java.net.Socket?,
+            ) = Unit
+
+            override fun checkClientTrusted(
+                chain: Array<out X509Certificate>?,
+                authType: String?,
+                engine: javax.net.ssl.SSLEngine?,
+            ) = Unit
+
+            override fun checkServerTrusted(chain: Array<out X509Certificate>?, authType: String?) = Unit
+
+            override fun checkServerTrusted(
+                chain: Array<out X509Certificate>?,
+                authType: String?,
+                socket: java.net.Socket?,
+            ) = Unit
+
+            override fun checkServerTrusted(
+                chain: Array<out X509Certificate>?,
+                authType: String?,
+                engine: javax.net.ssl.SSLEngine?,
+            ) = Unit
+
+            override fun getAcceptedIssuers(): Array<X509Certificate> = emptyArray()
+        }
+
+        val trustManager =
+            AdbTlsTrustPolicy.Custom { _ -> customTrustManager }
+                .resolveTrustManager(target = AdbNetworkEndpoint(host = "192.168.0.10", port = 37099))
+
+        assertSame(customTrustManager, trustManager)
+    }
+
+    private fun generatePublicKey(): PublicKey =
+        KeyPairGenerator.getInstance("RSA").apply {
+            initialize(2048)
+        }.generateKeyPair().public
+
+    private fun fakeCertificate(publicKey: PublicKey): X509Certificate =
+        object : X509Certificate() {
+            override fun getPublicKey(): PublicKey = publicKey
+
+            override fun checkValidity() = Unit
+
+            override fun checkValidity(date: Date?) = Unit
+
+            override fun getVersion(): Int = 3
+
+            override fun getSerialNumber(): BigInteger = BigInteger.ONE
+
+            override fun getIssuerDN(): Principal = Principal { "CN=test" }
+
+            override fun getSubjectDN(): Principal = Principal { "CN=test" }
+
+            override fun getNotBefore(): Date = Date(0)
+
+            override fun getNotAfter(): Date = Date(Long.MAX_VALUE)
+
+            override fun getTBSCertificate(): ByteArray = byteArrayOf()
+
+            override fun getSignature(): ByteArray = byteArrayOf()
+
+            override fun getSigAlgName(): String = "NONE"
+
+            override fun getSigAlgOID(): String = "0.0"
+
+            override fun getSigAlgParams(): ByteArray? = null
+
+            override fun getIssuerUniqueID(): BooleanArray? = null
+
+            override fun getSubjectUniqueID(): BooleanArray? = null
+
+            override fun getKeyUsage(): BooleanArray? = null
+
+            override fun getBasicConstraints(): Int = -1
+
+            override fun getEncoded(): ByteArray = throw CertificateEncodingException("Not implemented in test certificate")
+
+            override fun verify(key: PublicKey?) = Unit
+
+            override fun verify(key: PublicKey?, sigProvider: String?) = Unit
+
+            override fun toString(): String = "FakeX509Certificate"
+
+            override fun hasUnsupportedCriticalExtension(): Boolean = false
+
+            override fun getCriticalExtensionOIDs(): MutableSet<String>? = null
+
+            override fun getNonCriticalExtensionOIDs(): MutableSet<String>? = null
+
+            override fun getExtensionValue(oid: String?): ByteArray? = null
+        }
+}

--- a/dadb-android/src/test/kotlin/dadb/android/tls/AdbTlsErrorMapperTest.kt
+++ b/dadb-android/src/test/kotlin/dadb/android/tls/AdbTlsErrorMapperTest.kt
@@ -1,0 +1,34 @@
+package dadb.android.tls
+
+import java.io.IOException
+import java.net.SocketTimeoutException
+import javax.net.ssl.SSLHandshakeException
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AdbTlsErrorMapperTest {
+    @Test
+    fun map_authRelatedHandshake_returnsTlsAuthException() {
+        val error = AdbTlsErrorMapper.map(SSLHandshakeException("certificate_required"))
+
+        assertTrue(error is AdbTlsAuthException)
+    }
+
+    @Test
+    fun map_timeout_returnsHandshakeTimeoutIoException() {
+        val timeout = SocketTimeoutException("read timed out")
+        val error = AdbTlsErrorMapper.map(IOException("handshake failed", timeout))
+
+        assertTrue(error is IOException)
+        assertEquals("TLS handshake timeout", error.message)
+    }
+
+    @Test
+    fun map_nonTlsFailure_returnsOriginalThrowable() {
+        val error = IOException("plain failure")
+
+        assertSame(error, AdbTlsErrorMapper.map(error))
+    }
+}

--- a/dadb-android/src/test/kotlin/dadb/android/tls/AdbTlsSocketsTest.kt
+++ b/dadb-android/src/test/kotlin/dadb/android/tls/AdbTlsSocketsTest.kt
@@ -1,0 +1,31 @@
+package dadb.android.tls
+
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class AdbTlsSocketsTest {
+    @Test
+    fun requiredClientProtocols_returnsTls13Only() {
+        val protocols = AdbTlsSockets.requiredClientProtocols(arrayOf("TLSv1.2", "TLSv1.3"))
+
+        assertArrayEquals(arrayOf("TLSv1.3"), protocols)
+    }
+
+    @Test
+    fun requiredClientProtocols_failsWithoutTls13() {
+        val error =
+            try {
+                AdbTlsSockets.requiredClientProtocols(arrayOf("TLSv1.2"))
+                null
+            } catch (t: IllegalStateException) {
+                t
+            }
+
+        requireNotNull(error)
+        assertEquals(
+            "Wireless Debugging TLS requires TLSv1.3, but the current runtime only supports: TLSv1.2",
+            error.message,
+        )
+    }
+}

--- a/dadb-android/src/test/kotlin/dadb/android/usb/AdbPacketCodecTest.kt
+++ b/dadb-android/src/test/kotlin/dadb/android/usb/AdbPacketCodecTest.kt
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2021 mobile.dev inc.
+ * Android USB transport support by github.com/XRSec/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package dadb.android.usb
+
+import okio.Buffer
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertThrows
+import org.junit.Test
+import java.io.IOException
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+
+class AdbPacketCodecTest {
+
+    @Test
+    fun completePacketLength_partialPacket() {
+        val packet = buildPacket(command = 0x45545257, arg0 = 1, arg1 = 2, payload = "hello".toByteArray())
+        val pending = Buffer()
+
+        pending.write(packet, 0, AdbPacketCodec.HEADER_LENGTH - 1)
+        assertNull(AdbPacketCodec.completePacketLength(pending))
+
+        pending.write(packet, AdbPacketCodec.HEADER_LENGTH - 1, 1)
+        assertNull(AdbPacketCodec.completePacketLength(pending))
+
+        pending.write(packet, AdbPacketCodec.HEADER_LENGTH, packet.size - AdbPacketCodec.HEADER_LENGTH)
+        assertEquals(packet.size.toLong(), AdbPacketCodec.completePacketLength(pending))
+    }
+
+    @Test
+    fun completePacketLength_multiplePackets() {
+        val firstPacket = buildPacket(command = 0x4e45504f, arg0 = 7, arg1 = 0, payload = "shell,v2,raw:echo one\u0000".toByteArray())
+        val secondPacket = buildPacket(command = 0x45545257, arg0 = 7, arg1 = 8, payload = "two".toByteArray())
+        val pending = Buffer().write(firstPacket).write(secondPacket)
+
+        val firstLength = AdbPacketCodec.completePacketLength(pending)
+        assertEquals(firstPacket.size.toLong(), firstLength)
+        assertEquals(firstPacket.size.toLong(), pending.readByteArray(firstLength!!).size.toLong())
+
+        val secondLength = AdbPacketCodec.completePacketLength(pending)
+        assertEquals(secondPacket.size.toLong(), secondLength)
+    }
+
+    @Test
+    fun parseHeader_invalidMagic() {
+        val header = buildPacket(command = 0x59414b4f, arg0 = 11, arg1 = 22, payload = ByteArray(0)).copyOf(AdbPacketCodec.HEADER_LENGTH)
+        ByteBuffer.wrap(header).order(ByteOrder.LITTLE_ENDIAN).putInt(20, 0)
+
+        assertThrows(IOException::class.java) {
+            AdbPacketCodec.parseHeader(header)
+        }
+    }
+
+    private fun buildPacket(
+        command: Int,
+        arg0: Int,
+        arg1: Int,
+        payload: ByteArray,
+    ): ByteArray {
+        val buffer = ByteBuffer.allocate(AdbPacketCodec.HEADER_LENGTH + payload.size).order(ByteOrder.LITTLE_ENDIAN)
+        buffer.putInt(command)
+        buffer.putInt(arg0)
+        buffer.putInt(arg1)
+        buffer.putInt(payload.size)
+        buffer.putInt(payload.sumOf { it.toUByte().toInt() })
+        buffer.putInt(command xor -0x1)
+        buffer.put(payload)
+        return buffer.array()
+    }
+}

--- a/dadb-android/src/test/kotlin/dadb/android/wireless/AdbPairingProtocolTest.kt
+++ b/dadb-android/src/test/kotlin/dadb/android/wireless/AdbPairingProtocolTest.kt
@@ -1,0 +1,190 @@
+package dadb.android.wireless
+
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AdbPairingProtocolTest {
+    @Test
+    fun pairingProtocolConstants_matchAdbProtocolExpectations() {
+        assertEquals(1.toByte(), CURRENT_KEY_HEADER_VERSION)
+        assertEquals(1.toByte(), MIN_SUPPORTED_KEY_HEADER_VERSION)
+        assertEquals(1.toByte(), MAX_SUPPORTED_KEY_HEADER_VERSION)
+        assertEquals(8192, MAX_PEER_INFO_SIZE)
+        assertEquals(MAX_PEER_INFO_SIZE * 2, MAX_PAYLOAD_SIZE)
+        assertEquals(6, PAIRING_PACKET_HEADER_SIZE)
+        assertEquals("adb-label\u0000", EXPORTED_KEY_LABEL)
+        assertEquals(64, EXPORTED_KEY_SIZE)
+    }
+
+    @Test
+    fun pairingPacketHeader_roundTripsValidHeader() {
+        val header =
+            PairingPacketHeader(
+                version = CURRENT_KEY_HEADER_VERSION,
+                type = PairingPacketHeader.Type.SPAKE2_MSG,
+                payload = 128,
+            )
+
+        val buffer = ByteBuffer.allocate(PAIRING_PACKET_HEADER_SIZE).order(ByteOrder.BIG_ENDIAN)
+        header.writeTo(buffer)
+
+        val decoded =
+            PairingPacketHeader.readFrom(
+                ByteBuffer.wrap(buffer.array()).order(ByteOrder.BIG_ENDIAN),
+            )
+
+        requireNotNull(decoded)
+        assertEquals(CURRENT_KEY_HEADER_VERSION, decoded.version)
+        assertEquals(PairingPacketHeader.Type.SPAKE2_MSG, decoded.type)
+        assertEquals(128, decoded.payload)
+    }
+
+    @Test
+    fun pairingPacketHeader_rejectsUnsupportedVersion() {
+        val decoded = decodeHeader(version = 2, type = PairingPacketHeader.Type.SPAKE2_MSG.toInt(), payload = 16)
+
+        assertNull(decoded)
+    }
+
+    @Test
+    fun pairingPacketHeader_rejectsUnknownType() {
+        val decoded = decodeHeader(version = 1, type = 9, payload = 16)
+
+        assertNull(decoded)
+    }
+
+    @Test
+    fun pairingPacketHeader_rejectsUnsafePayloadSizes() {
+        assertNull(decodeHeader(version = 1, type = PairingPacketHeader.Type.PEER_INFO.toInt(), payload = 0))
+        assertNull(
+            decodeHeader(
+                version = 1,
+                type = PairingPacketHeader.Type.PEER_INFO.toInt(),
+                payload = MAX_PAYLOAD_SIZE + 1,
+            ),
+        )
+    }
+
+    @Test
+    fun stateMachine_allowsExpectedHappyPathTransitions() {
+        val exchangingMsgs = PairingClientStateMachine.start(PairingClientState.READY)
+        val exchangingPeerInfo =
+            PairingClientStateMachine.afterMessageExchange(
+                exchangingMsgs,
+                success = true,
+            )
+        val stopped =
+            PairingClientStateMachine.afterPeerInfoExchange(
+                exchangingPeerInfo,
+                success = true,
+            )
+
+        assertEquals(PairingClientState.EXCHANGING_MSGS, exchangingMsgs)
+        assertEquals(PairingClientState.EXCHANGING_PEER_INFO, exchangingPeerInfo)
+        assertEquals(PairingClientState.STOPPED, stopped)
+    }
+
+    @Test
+    fun stateMachine_stopsAfterFailedMessageExchange() {
+        val exchangingMsgs = PairingClientStateMachine.start(PairingClientState.READY)
+
+        val stopped =
+            PairingClientStateMachine.afterMessageExchange(
+                exchangingMsgs,
+                success = false,
+            )
+
+        assertEquals(PairingClientState.STOPPED, stopped)
+    }
+
+    @Test
+    fun stateMachine_rejectsInvalidTransition() {
+        val error =
+            try {
+                PairingClientStateMachine.afterPeerInfoExchange(PairingClientState.READY, success = true)
+                null
+            } catch (t: IllegalStateException) {
+                t
+            }
+
+        requireNotNull(error)
+        assertTrue(error.message.orEmpty().contains("EXCHANGING_PEER_INFO"))
+    }
+
+    @Test
+    fun decodePeerAdbPublicKey_throwsForInvalidPairingCode() {
+        val error =
+            try {
+                decodePeerAdbPublicKey(null)
+                null
+            } catch (t: AdbInvalidPairingCodeException) {
+                t
+            }
+
+        requireNotNull(error)
+    }
+
+    @Test
+    fun decodePeerAdbPublicKey_returnsNullForInvalidPeerInfoSize() {
+        var invalidSize: Int? = null
+
+        val decoded =
+            decodePeerAdbPublicKey(
+                ByteArray(MAX_PEER_INFO_SIZE - 1),
+                onInvalidSize = { invalidSize = it },
+            )
+
+        assertNull(decoded)
+        assertEquals(MAX_PEER_INFO_SIZE - 1, invalidSize)
+    }
+
+    @Test
+    fun decodePeerAdbPublicKey_trimsTrailingZeroPadding() {
+        val payload = ByteBuffer.allocate(MAX_PEER_INFO_SIZE).order(ByteOrder.BIG_ENDIAN)
+        payload.put(PairingPeerInfo.ADB_RSA_PUB_KEY)
+        payload.put("adb-rsa AAAA test@device".toByteArray())
+
+        val decoded = decodePeerAdbPublicKey(payload.array())
+
+        requireNotNull(decoded)
+        assertArrayEquals("adb-rsa AAAA test@device".toByteArray(), decoded)
+    }
+
+    @Test
+    fun pairInfo_roundTripsAndTruncatesOversizedData() {
+        val raw = ByteArray(MAX_PEER_INFO_SIZE + 32) { 'A'.code.toByte() }
+        val info = PairingPeerInfo(PairingPeerInfo.ADB_RSA_PUB_KEY, raw)
+        val buffer = ByteBuffer.allocate(MAX_PEER_INFO_SIZE).order(ByteOrder.BIG_ENDIAN)
+
+        info.writeTo(buffer)
+
+        val decoded = PairingPeerInfo.readFrom(ByteBuffer.wrap(buffer.array()).order(ByteOrder.BIG_ENDIAN))
+
+        assertEquals(PairingPeerInfo.ADB_RSA_PUB_KEY, decoded.type)
+        assertEquals(MAX_PEER_INFO_SIZE - 1, decoded.data.size)
+        assertTrue(decoded.data.all { it == 'A'.code.toByte() })
+    }
+
+    private fun decodeHeader(
+        version: Int,
+        type: Int,
+        payload: Int,
+    ): PairingPacketHeader? {
+        val bytes =
+            ByteBuffer.allocate(PAIRING_PACKET_HEADER_SIZE).order(ByteOrder.BIG_ENDIAN).apply {
+                put(version.toByte())
+                put(type.toByte())
+                putInt(payload)
+            }.array()
+
+        return PairingPacketHeader.readFrom(
+            ByteBuffer.wrap(bytes).order(ByteOrder.BIG_ENDIAN),
+            logError = {},
+        )
+    }
+}

--- a/dadb-helper/build.gradle.kts
+++ b/dadb-helper/build.gradle.kts
@@ -1,0 +1,80 @@
+import java.util.Properties
+import org.gradle.api.tasks.Exec
+import org.gradle.api.tasks.bundling.Zip
+
+plugins {
+    `java-library`
+}
+
+val localProperties = Properties().apply {
+    val file = rootProject.file("local.properties")
+    if (file.exists()) {
+        file.inputStream().use(::load)
+    }
+}
+
+val androidSdkDir =
+    sequenceOf(
+        providers.environmentVariable("ANDROID_HOME").orNull,
+        providers.environmentVariable("ANDROID_SDK_ROOT").orNull,
+        localProperties.getProperty("sdk.dir"),
+    ).firstOrNull { !it.isNullOrBlank() }
+        ?: error("Android SDK not found. Set ANDROID_HOME, ANDROID_SDK_ROOT, or sdk.dir in local.properties")
+
+val buildToolsDir =
+    file("$androidSdkDir/build-tools")
+        .listFiles()
+        ?.filter { it.isDirectory }
+        ?.maxByOrNull { it.name }
+        ?: error("Android build-tools not found under $androidSdkDir/build-tools")
+
+val androidJar = file("$androidSdkDir/platforms/android-36/android.jar")
+val d8Executable = File(buildToolsDir, "d8")
+
+dependencies {
+    compileOnly(files(androidJar))
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+}
+
+val helperClassesJar =
+    tasks.named<Jar>("jar") {
+        archiveBaseName.set("dadb-icon-helper-classes")
+        manifest {
+            attributes["Main-Class"] = "dadb.helper.AppIconExportMain"
+        }
+    }
+
+val dexOutputDir = layout.buildDirectory.dir("intermediates/dadb-helper-d8")
+
+val dexHelperClasses by tasks.registering(Exec::class) {
+    dependsOn(helperClassesJar)
+    inputs.file(helperClassesJar.flatMap { it.archiveFile })
+    outputs.dir(dexOutputDir)
+    doFirst {
+        delete(dexOutputDir)
+        dexOutputDir.get().asFile.mkdirs()
+    }
+    commandLine(
+        d8Executable.absolutePath,
+        "--min-api",
+        "23",
+        "--lib",
+        androidJar.absolutePath,
+        "--output",
+        dexOutputDir.get().asFile.absolutePath,
+        helperClassesJar.get().archiveFile.get().asFile.absolutePath,
+    )
+}
+
+tasks.register<Zip>("dexJar") {
+    dependsOn(dexHelperClasses)
+    from(dexOutputDir)
+    include("classes.dex")
+    archiveBaseName.set("dadb-icon-helper")
+    archiveExtension.set("jar")
+    destinationDirectory.set(layout.buildDirectory.dir("libs"))
+}

--- a/dadb-helper/src/main/java/dadb/helper/AppIconExportMain.java
+++ b/dadb-helper/src/main/java/dadb/helper/AppIconExportMain.java
@@ -1,0 +1,641 @@
+package dadb.helper;
+
+import android.annotation.SuppressLint;
+import android.content.Context;
+import android.content.pm.ApplicationInfo;
+import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
+import android.content.res.Resources;
+import android.graphics.Bitmap;
+import android.graphics.Canvas;
+import android.graphics.drawable.Drawable;
+import android.os.Build;
+import android.os.Looper;
+import android.util.Base64;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+public final class AppIconExportMain {
+    private static final int ICON_SIZE = 96;
+    private static final int MAX_ICON_THREADS = 4;
+    private static final String USAGE =
+            "usage: ping | runtime | context | pm | apps | " +
+                    "probe_classload | probe_current | probe_systemmain | probe_systemcontext | " +
+                    "probe_pmservice | probe_appglobals_pm | probe_apppm_ctors | probe_apppm_ctor | " +
+                    "probe_apppm_apps | probe_apppm_appinfo <packageName> | " +
+                    "probe_getpm | probe_apps | probe_appinfo <packageName> | " +
+                    "iconprobe <packageName> | list <offset> <limit> <includeSystem> | " +
+                    "icons <requestBase64> | " +
+                    "icon <packageName> [localHash]";
+
+    private AppIconExportMain() {}
+
+    private static final class BatchIconResult {
+        final String packageName;
+        final String label;
+        final String iconHash;
+        final String entryName;
+        final byte[] imageBytes;
+
+        BatchIconResult(
+                String packageName,
+                String label,
+                String iconHash,
+                String entryName,
+                byte[] imageBytes
+        ) {
+            this.packageName = packageName;
+            this.label = label;
+            this.iconHash = iconHash;
+            this.entryName = entryName;
+            this.imageBytes = imageBytes;
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        if (args.length < 1) {
+            System.err.println(USAGE);
+            System.exit(2);
+            return;
+        }
+
+        String command = args[0];
+        if ("ping".equals(command)) {
+            System.out.println("PING_OK");
+            return;
+        }
+
+        if ("runtime".equals(command)) {
+            Object activityThread = resolveActivityThread();
+            System.out.println(activityThread != null ? "RUNTIME_OK" : "RUNTIME_NULL");
+            return;
+        }
+
+        if ("probe_classload".equals(command)) {
+            Class<?> activityThreadClass = Class.forName("android.app.ActivityThread");
+            System.out.println("PROBE_CLASSLOAD_OK\t" + activityThreadClass.getName());
+            return;
+        }
+
+        if ("probe_current".equals(command)) {
+            Class<?> activityThreadClass = Class.forName("android.app.ActivityThread");
+            Object activityThread = activityThreadClass.getMethod("currentActivityThread").invoke(null);
+            System.out.println(
+                    activityThread != null
+                            ? "PROBE_CURRENT_OK\t" + activityThread.getClass().getName()
+                            : "PROBE_CURRENT_NULL"
+            );
+            return;
+        }
+
+        if ("probe_systemmain".equals(command)) {
+            Class<?> activityThreadClass = Class.forName("android.app.ActivityThread");
+            Object activityThread = activityThreadClass.getMethod("systemMain").invoke(null);
+            System.out.println(
+                    activityThread != null
+                            ? "PROBE_SYSTEMMAIN_OK\t" + activityThread.getClass().getName()
+                            : "PROBE_SYSTEMMAIN_NULL"
+            );
+            return;
+        }
+
+        if ("probe_pmservice".equals(command)) {
+            Class<?> serviceManagerClass = Class.forName("android.os.ServiceManager");
+            Object binder = serviceManagerClass.getMethod("getService", String.class).invoke(null, "package");
+            System.out.println(
+                    binder != null
+                            ? "PROBE_PMSERVICE_OK\t" + binder.getClass().getName()
+                            : "PROBE_PMSERVICE_NULL"
+            );
+            return;
+        }
+
+        if ("probe_appglobals_pm".equals(command)) {
+            Object ipm = getAppGlobalsPackageManager();
+            System.out.println(
+                    ipm != null
+                            ? "PROBE_APPGLOBALS_PM_OK\t" + ipm.getClass().getName()
+                            : "PROBE_APPGLOBALS_PM_NULL"
+            );
+            return;
+        }
+
+        if ("probe_apppm_ctors".equals(command)) {
+            Class<?> cls = Class.forName("android.app.ApplicationPackageManager");
+            for (java.lang.reflect.Constructor<?> constructor : cls.getDeclaredConstructors()) {
+                constructor.setAccessible(true);
+                Class<?>[] parameterTypes = constructor.getParameterTypes();
+                StringBuilder builder = new StringBuilder("PROBE_APPPM_CTOR\t");
+                builder.append(cls.getName()).append('(');
+                for (int i = 0; i < parameterTypes.length; i++) {
+                    if (i > 0) {
+                        builder.append(", ");
+                    }
+                    builder.append(parameterTypes[i].getName());
+                }
+                builder.append(')');
+                System.out.println(builder);
+            }
+            return;
+        }
+
+        if ("probe_apppm_ctor".equals(command)) {
+            PackageManager packageManager = createApplicationPackageManagerWithoutContext();
+            System.out.println("PROBE_APPPM_CTOR_OK\t" + packageManager.getClass().getName());
+            return;
+        }
+
+        if ("probe_apppm_apps".equals(command)) {
+            PackageManager packageManager = createApplicationPackageManagerWithoutContext();
+            List<ApplicationInfo> installedApps = packageManager.getInstalledApplications(0);
+            System.out.println("PROBE_APPPM_APPS_OK\t" + installedApps.size());
+            return;
+        }
+
+        if ("probe_apppm_appinfo".equals(command)) {
+            if (args.length < 2) {
+                System.err.println("usage: probe_apppm_appinfo <packageName>");
+                System.exit(2);
+                return;
+            }
+            PackageManager packageManager = createApplicationPackageManagerWithoutContext();
+            ApplicationInfo applicationInfo = packageManager.getApplicationInfo(args[1], 0);
+            System.out.println("PROBE_APPPM_APPINFO_OK\t" + applicationInfo.packageName);
+            return;
+        }
+
+        Context context = obtainSystemContext();
+        if (context == null) {
+            System.err.println("unable to obtain system context");
+            System.exit(3);
+            return;
+        }
+
+        if ("probe_systemcontext".equals(command)) {
+            System.out.println("PROBE_SYSTEMCONTEXT_OK\t" + context.getClass().getName());
+            return;
+        }
+
+        if ("context".equals(command)) {
+            System.out.println("CONTEXT_OK\t" + context.getClass().getName());
+            return;
+        }
+
+        if ("probe_getpm".equals(command)) {
+            PackageManager packageManager = context.getPackageManager();
+            System.out.println("PROBE_GETPM_OK\t" + packageManager.getClass().getName());
+            return;
+        }
+
+        if ("pm".equals(command)) {
+            PackageManager packageManager = context.getPackageManager();
+            System.out.println("PM_OK\t" + packageManager.getClass().getName());
+            return;
+        }
+
+        if ("probe_apps".equals(command)) {
+            PackageManager packageManager = context.getPackageManager();
+            List<ApplicationInfo> installedApps = packageManager.getInstalledApplications(0);
+            System.out.println("PROBE_APPS_OK\t" + installedApps.size());
+            return;
+        }
+
+        if ("apps".equals(command)) {
+            PackageManager packageManager = context.getPackageManager();
+            List<ApplicationInfo> installedApps = packageManager.getInstalledApplications(0);
+            System.out.println("APPS_OK\t" + installedApps.size());
+            return;
+        }
+
+        if ("probe_appinfo".equals(command)) {
+            if (args.length < 2) {
+                System.err.println("usage: probe_appinfo <packageName>");
+                System.exit(2);
+                return;
+            }
+            PackageManager packageManager = context.getPackageManager();
+            ApplicationInfo applicationInfo = packageManager.getApplicationInfo(args[1], 0);
+            System.out.println("PROBE_APPINFO_OK\t" + applicationInfo.packageName);
+            return;
+        }
+
+        if ("iconprobe".equals(command)) {
+            if (args.length < 2) {
+                System.err.println("usage: iconprobe <packageName>");
+                System.exit(2);
+                return;
+            }
+            handleIconProbeCommand(context, args[1]);
+            return;
+        }
+
+        if ("list".equals(command)) {
+            handleListCommand(context, args);
+            return;
+        }
+
+        if ("icons".equals(command)) {
+            if (args.length < 2) {
+                System.err.println("usage: icons <requestBase64>");
+                System.exit(2);
+                return;
+            }
+            handleIconsCommand(context, args[1]);
+            return;
+        }
+
+        if (!"icon".equals(command) || args.length < 2) {
+            System.err.println(USAGE);
+            System.exit(2);
+            return;
+        }
+
+        String packageName = args[1];
+        String localHash = args.length >= 3 ? args[2] : "";
+
+        PackageManager packageManager = context.getPackageManager();
+        ApplicationInfo applicationInfo = packageManager.getApplicationInfo(packageName, 0);
+        String label = String.valueOf(packageManager.getApplicationLabel(applicationInfo));
+        Drawable icon = loadIcon(packageName, context, packageManager, applicationInfo);
+        Bitmap bitmap = drawableToBitmap(icon);
+        String argbHash = hashArgb(bitmap);
+
+        String labelBase64 =
+                Base64.encodeToString(label.getBytes(StandardCharsets.UTF_8), Base64.NO_WRAP);
+
+        if (!localHash.isEmpty() && localHash.equals(argbHash)) {
+            System.out.println("UNCHANGED");
+            System.out.println(argbHash);
+            System.out.println(labelBase64);
+            return;
+        }
+
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        compressBitmap(bitmap, output);
+
+        String iconBase64 = Base64.encodeToString(output.toByteArray(), Base64.NO_WRAP);
+
+        System.out.println("CHANGED");
+        System.out.println(argbHash);
+        System.out.println(labelBase64);
+        System.out.println(iconBase64);
+    }
+
+    private static void handleListCommand(Context context, String[] args) throws Exception {
+        if (args.length < 4) {
+            System.err.println("usage: list <offset> <limit> <includeSystem>");
+            System.exit(2);
+            return;
+        }
+
+        int offset = Integer.parseInt(args[1]);
+        int limit = Integer.parseInt(args[2]);
+        boolean includeSystem = "1".equals(args[3]) || Boolean.parseBoolean(args[3]);
+
+        PackageManager packageManager = context.getPackageManager();
+        List<ApplicationInfo> installedApps = new ArrayList<>(packageManager.getInstalledApplications(0));
+        Collections.sort(
+                installedApps,
+                new Comparator<ApplicationInfo>() {
+                    @Override
+                    public int compare(ApplicationInfo left, ApplicationInfo right) {
+                        int systemCompare = Boolean.compare(isSystemApp(left), isSystemApp(right));
+                        if (systemCompare != 0) {
+                            return systemCompare;
+                        }
+
+                        int enabledCompare = Boolean.compare(!left.enabled, !right.enabled);
+                        if (enabledCompare != 0) {
+                            return enabledCompare;
+                        }
+
+                        return left.packageName.compareTo(right.packageName);
+                    }
+                }
+        );
+
+        int emitted = 0;
+        int skipped = 0;
+        for (ApplicationInfo appInfo : installedApps) {
+            boolean isSystemApp = isSystemApp(appInfo);
+            if (!includeSystem && isSystemApp) {
+                continue;
+            }
+
+            if (skipped < offset) {
+                skipped++;
+                continue;
+            }
+
+            if (emitted >= limit) {
+                break;
+            }
+
+            PackageInfo packageInfo = packageManager.getPackageInfo(appInfo.packageName, 0);
+            String label = String.valueOf(packageManager.getApplicationLabel(appInfo));
+            long versionCode = getLongVersionCode(packageInfo);
+            long lastUpdateTime = packageInfo.lastUpdateTime;
+
+            System.out.println(
+                    appInfo.packageName + "\t" +
+                            base64(label) + "\t" +
+                            (appInfo.enabled ? "1" : "0") + "\t" +
+                            (isSystemApp ? "1" : "0") + "\t" +
+                            base64(appInfo.sourceDir != null ? appInfo.sourceDir : "") + "\t" +
+                            versionCode + "\t" +
+                            lastUpdateTime
+            );
+            emitted++;
+        }
+    }
+
+    private static void handleIconProbeCommand(Context context, String packageName) throws Exception {
+        PackageManager packageManager = context.getPackageManager();
+        System.out.println("ICON_PROBE_START\t" + packageName);
+        ApplicationInfo applicationInfo = packageManager.getApplicationInfo(packageName, 0);
+        System.out.println("ICON_PROBE_APPINFO_OK");
+        String label = String.valueOf(packageManager.getApplicationLabel(applicationInfo));
+        System.out.println("ICON_PROBE_LABEL_OK\t" + label);
+        Drawable icon = loadIcon(packageName, context, packageManager, applicationInfo);
+        System.out.println("ICON_PROBE_LOADICON_OK\t" + icon.getClass().getName());
+        Bitmap bitmap = drawableToBitmap(icon);
+        System.out.println("ICON_PROBE_RENDER_OK\t" + bitmap.getWidth() + "x" + bitmap.getHeight());
+    }
+
+    private static void handleIconsCommand(Context context, String requestBase64) throws Exception {
+        String requestText = new String(Base64.decode(requestBase64, Base64.NO_WRAP), StandardCharsets.UTF_8);
+        PackageManager packageManager = context.getPackageManager();
+        List<String> requestLines = new ArrayList<>();
+        for (String line : requestText.split("\n")) {
+            String trimmed = line.trim();
+            if (!trimmed.isEmpty()) {
+                requestLines.add(trimmed);
+            }
+        }
+
+        int threadCount = Math.min(MAX_ICON_THREADS, Math.max(1, Runtime.getRuntime().availableProcessors()));
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        List<Future<BatchIconResult>> futures = new ArrayList<>();
+        try {
+            for (String line : requestLines) {
+                futures.add(executor.submit(() -> processBatchIconRequest(context, packageManager, line)));
+            }
+        } finally {
+            executor.shutdown();
+        }
+
+        List<BatchIconResult> results = new ArrayList<>();
+        for (Future<BatchIconResult> future : futures) {
+            try {
+                BatchIconResult result = future.get();
+                if (result != null) {
+                    results.add(result);
+                }
+            } catch (Exception ignored) {
+            }
+        }
+
+        List<String> manifestLines = new ArrayList<>();
+        ByteArrayOutputStream zipBytes = new ByteArrayOutputStream();
+        try (ZipOutputStream zipOutputStream = new ZipOutputStream(zipBytes)) {
+            for (BatchIconResult result : results) {
+                if (result.imageBytes != null) {
+                    zipOutputStream.putNextEntry(new ZipEntry(result.entryName));
+                    zipOutputStream.write(result.imageBytes);
+                    zipOutputStream.closeEntry();
+                }
+                manifestLines.add(
+                        result.packageName + "\t" +
+                                base64(result.label) + "\t" +
+                                result.iconHash + "\t" +
+                                result.entryName
+                );
+            }
+        }
+
+        String manifestBase64 =
+                manifestLines.isEmpty()
+                        ? "-"
+                        : Base64.encodeToString(
+                                joinLines(manifestLines).getBytes(StandardCharsets.UTF_8),
+                                Base64.NO_WRAP
+                        );
+        boolean hasChangedIcons = hasChangedIcons(results);
+        String zipBase64 =
+                manifestLines.isEmpty() || !hasChangedIcons
+                        ? "-"
+                        : Base64.encodeToString(zipBytes.toByteArray(), Base64.NO_WRAP);
+
+        System.out.println("BATCH");
+        System.out.println(manifestBase64);
+        System.out.println(zipBase64);
+    }
+
+    private static BatchIconResult processBatchIconRequest(
+            Context context,
+            PackageManager packageManager,
+            String line
+    ) {
+        try {
+            String[] parts = line.split("\t", 2);
+            String packageName = parts[0].trim();
+            if (packageName.isEmpty()) {
+                return null;
+            }
+
+            String localHash = parts.length >= 2 ? parts[1].trim() : "";
+            ApplicationInfo applicationInfo = packageManager.getApplicationInfo(packageName, 0);
+            String label = String.valueOf(packageManager.getApplicationLabel(applicationInfo));
+            Drawable icon = loadIcon(packageName, context, packageManager, applicationInfo);
+            if (icon == null) {
+                return null;
+            }
+
+            Bitmap bitmap = drawableToBitmap(icon);
+            String iconHash = hashArgb(bitmap);
+            if (!localHash.isEmpty() && localHash.equals(iconHash)) {
+                return new BatchIconResult(packageName, label, iconHash, "-", null);
+            }
+
+            ByteArrayOutputStream iconOutput = new ByteArrayOutputStream();
+            compressBitmap(bitmap, iconOutput);
+            String entryName = sanitizeEntryName(packageName) + ".webp";
+            return new BatchIconResult(packageName, label, iconHash, entryName, iconOutput.toByteArray());
+        } catch (Exception ignored) {
+            return null;
+        }
+    }
+
+    private static String joinLines(List<String> lines) {
+        StringBuilder builder = new StringBuilder();
+        for (int i = 0; i < lines.size(); i++) {
+            if (i > 0) {
+                builder.append('\n');
+            }
+            builder.append(lines.get(i));
+        }
+        return builder.toString();
+    }
+
+    private static boolean hasChangedIcons(List<BatchIconResult> results) {
+        for (BatchIconResult result : results) {
+            if (result.imageBytes != null) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static Context obtainSystemContext() throws Exception {
+        prepareMainLooperIfNeeded();
+        Object activityThread = resolveActivityThread();
+        if (activityThread == null) {
+            return null;
+        }
+        Class<?> activityThreadClass = Class.forName("android.app.ActivityThread");
+        return (Context) activityThreadClass.getMethod("getSystemContext").invoke(activityThread);
+    }
+
+    private static void prepareMainLooperIfNeeded() {
+        if (Looper.getMainLooper() == null) {
+            Looper.prepareMainLooper();
+        }
+    }
+
+    private static Object resolveActivityThread() throws Exception {
+        Class<?> activityThreadClass = Class.forName("android.app.ActivityThread");
+        Object activityThread;
+        try {
+            activityThread = activityThreadClass.getMethod("currentActivityThread").invoke(null);
+        } catch (Throwable ignored) {
+            activityThread = null;
+        }
+        if (activityThread == null) {
+            prepareMainLooperIfNeeded();
+            activityThread = activityThreadClass.getMethod("systemMain").invoke(null);
+        }
+        return activityThread;
+    }
+
+    private static Object getAppGlobalsPackageManager() throws Exception {
+        Class<?> appGlobalsClass = Class.forName("android.app.AppGlobals");
+        return appGlobalsClass.getMethod("getPackageManager").invoke(null);
+    }
+
+    private static PackageManager createApplicationPackageManagerWithoutContext() throws Exception {
+        Object ipm = getAppGlobalsPackageManager();
+        if (ipm == null) {
+            throw new IllegalStateException("AppGlobals.getPackageManager returned null");
+        }
+
+        Class<?> cls = Class.forName("android.app.ApplicationPackageManager");
+        for (java.lang.reflect.Constructor<?> constructor : cls.getDeclaredConstructors()) {
+            Class<?>[] parameterTypes = constructor.getParameterTypes();
+            if (parameterTypes.length == 2
+                    && "android.content.pm.IPackageManager".equals(parameterTypes[1].getName())) {
+                constructor.setAccessible(true);
+                Object instance = constructor.newInstance(null, ipm);
+                return (PackageManager) instance;
+            }
+        }
+
+        throw new NoSuchMethodException("No ApplicationPackageManager constructor with IPackageManager found");
+    }
+
+    private static Drawable loadIcon(
+            String packageName,
+            Context context,
+            PackageManager packageManager,
+            ApplicationInfo applicationInfo
+    ) throws Exception {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.ICE_CREAM_SANDWICH_MR1) {
+            try {
+                PackageInfo packageInfo = packageManager.getPackageInfo(packageName, 0);
+                Context packageContext = context.createPackageContext(packageName, Context.CONTEXT_IGNORE_SECURITY);
+                int[] densities = {320, 240, 213};
+                for (int density : densities) {
+                    try {
+                        Drawable drawable =
+                                packageContext.getResources().getDrawableForDensity(
+                                        packageInfo.applicationInfo.icon,
+                                        density,
+                                        null
+                                );
+                        if (drawable != null) {
+                            return drawable;
+                        }
+                    } catch (Resources.NotFoundException ignored) {
+                    }
+                }
+            } catch (Exception ignored) {
+            }
+        }
+
+        return applicationInfo.loadIcon(packageManager);
+    }
+
+    private static String sanitizeEntryName(String packageName) {
+        return packageName.replace(':', '_');
+    }
+
+    private static Bitmap drawableToBitmap(Drawable drawable) {
+        Bitmap bitmap = Bitmap.createBitmap(ICON_SIZE, ICON_SIZE, Bitmap.Config.ARGB_8888);
+        Canvas canvas = new Canvas(bitmap);
+        drawable.setBounds(0, 0, canvas.getWidth(), canvas.getHeight());
+        drawable.draw(canvas);
+        return bitmap;
+    }
+
+    private static boolean isSystemApp(ApplicationInfo info) {
+        return (info.flags & ApplicationInfo.FLAG_SYSTEM) != 0
+                || (info.flags & ApplicationInfo.FLAG_UPDATED_SYSTEM_APP) != 0;
+    }
+
+    @SuppressWarnings("deprecation")
+    private static long getLongVersionCode(PackageInfo packageInfo) {
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.P) {
+            return packageInfo.getLongVersionCode();
+        }
+        return packageInfo.versionCode;
+    }
+
+    private static String base64(String value) {
+        return Base64.encodeToString(value.getBytes(StandardCharsets.UTF_8), Base64.NO_WRAP);
+    }
+
+    private static String hashArgb(Bitmap bitmap) throws Exception {
+        int[] pixels = new int[bitmap.getWidth() * bitmap.getHeight()];
+        bitmap.getPixels(pixels, 0, bitmap.getWidth(), 0, 0, bitmap.getWidth(), bitmap.getHeight());
+        ByteBuffer buffer = ByteBuffer.allocate(pixels.length * 4);
+        for (int pixel : pixels) {
+            buffer.putInt(pixel);
+        }
+        byte[] digest = MessageDigest.getInstance("SHA-256").digest(buffer.array());
+        StringBuilder builder = new StringBuilder(digest.length * 2);
+        for (byte value : digest) {
+            builder.append(String.format("%02x", value));
+        }
+        return builder.toString();
+    }
+
+    @SuppressWarnings("deprecation")
+    private static void compressBitmap(Bitmap bitmap, ByteArrayOutputStream output) {
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.R) {
+            bitmap.compress(Bitmap.CompressFormat.WEBP_LOSSLESS, 100, output);
+        } else {
+            bitmap.compress(Bitmap.CompressFormat.WEBP, 100, output);
+        }
+    }
+}

--- a/dadb/build.gradle.kts
+++ b/dadb/build.gradle.kts
@@ -1,5 +1,3 @@
-import org.gradle.internal.jvm.inspection.DefaultJvmMetadataDetector
-
 plugins {
     `maven-publish`
     id("org.jetbrains.kotlin.jvm")
@@ -12,15 +10,13 @@ repositories {
 }
 
 dependencies {
-    api("com.squareup.okio:okio:2.10.0")
+    api("com.squareup.okio:okio:3.17.0")
     implementation(platform("org.jetbrains.kotlin:kotlin-bom"))
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
 
     testImplementation("org.jetbrains.kotlin:kotlin-test")
-    testImplementation("com.google.truth:truth:1.0.1")
+    testImplementation("com.google.truth:truth:1.4.5")
 }
-
-val metadataDetector = objects.newInstance(DefaultJvmMetadataDetector::class.java)
 
 tasks.test {
     useJUnitPlatform()

--- a/dadb/src/main/kotlin/dadb/AdbConnection.kt
+++ b/dadb/src/main/kotlin/dadb/AdbConnection.kt
@@ -17,14 +17,18 @@
 
 package dadb
 
+import dadb.forwarding.StreamForwarder
 import okio.Sink
 import okio.Source
+import okio.buffer
 import okio.sink
 import okio.source
 import org.jetbrains.annotations.TestOnly
 import java.io.IOException
 import java.net.Socket
 import java.util.*
+import java.util.concurrent.ConcurrentLinkedQueue
+import kotlin.concurrent.thread
 
 internal class AdbConnection internal constructor(
         adbReader: AdbReader,
@@ -38,16 +42,38 @@ internal class AdbConnection internal constructor(
 
     private val random = Random()
     private val messageQueue = AdbMessageQueue(adbReader)
+    private val reverseSessionThreads = ConcurrentLinkedQueue<Thread>()
+    private val delayedAckEnabled = supportedFeatures.contains(Constants.FEATURE_DELAYED_ACK)
+
+    @Volatile
+    private var reverseThread: Thread? = null
+
+    @Volatile
+    private var closed = false
+
+    init {
+        startReverseBridgeLoop()
+    }
 
     @Throws(IOException::class)
     fun open(destination: String): AdbStream {
         val localId = newId()
         messageQueue.startListening(localId)
         try {
-            adbWriter.writeOpen(localId, destination)
+            val initialReceiveWindow = if (delayedAckEnabled) Constants.INITIAL_DELAYED_ACK_BYTES else 0
+            adbWriter.writeOpen(localId, destination, initialReceiveWindow)
             val message = messageQueue.take(localId, Constants.CMD_OKAY)
             val remoteId = message.arg0
-            return AdbStreamImpl(messageQueue, adbWriter, maxPayloadSize, localId, remoteId)
+            val initialAvailableSendBytes = Constants.decodeOkayAckBytes(message, delayedAckEnabled).toLong()
+            return AdbStreamImpl(
+                messageQueue = messageQueue,
+                adbWriter = adbWriter,
+                maxPayloadSize = maxPayloadSize,
+                localId = localId,
+                remoteId = remoteId,
+                delayedAckEnabled = delayedAckEnabled,
+                initialAvailableSendBytes = initialAvailableSendBytes,
+            )
         } catch (e: Throwable) {
             messageQueue.stopListening(localId)
             throw e
@@ -63,7 +89,11 @@ internal class AdbConnection internal constructor(
     }
 
     private fun newId(): Int {
-        return random.nextInt()
+        var id: Int
+        do {
+            id = random.nextInt()
+        } while (id == 0)
+        return id
     }
 
     @TestOnly
@@ -72,14 +102,124 @@ internal class AdbConnection internal constructor(
     }
 
     override fun close() {
+        closed = true
         try {
+            reverseThread?.interrupt()
+            reverseThread = null
+            while (true) {
+                val thread = reverseSessionThreads.poll() ?: break
+                thread.interrupt()
+            }
+            runCatching { messageQueue.stopListening(REVERSE_LISTENER_ID) }
             messageQueue.close()
             adbWriter.close()
             closeable?.close()
         } catch (ignore: Throwable) {}
     }
 
+    private fun startReverseBridgeLoop() {
+        messageQueue.startListening(REVERSE_LISTENER_ID)
+        reverseThread = thread(name = "dadb-reverse-accept") {
+            while (!Thread.currentThread().isInterrupted && !closed) {
+                try {
+                    val openMessage = messageQueue.take(REVERSE_LISTENER_ID, Constants.CMD_OPEN)
+                    handleIncomingReverseOpen(openMessage)
+                } catch (_: InterruptedException) {
+                    return@thread
+                } catch (_: AdbStreamClosed) {
+                    if (closed) {
+                        return@thread
+                    }
+                    messageQueue.startListening(REVERSE_LISTENER_ID)
+                } catch (t: Throwable) {
+                    if (!closed && !Thread.currentThread().isInterrupted) {
+                        log { "reverse bridge loop error: ${t.message}" }
+                    }
+                }
+            }
+        }
+    }
+
+    private fun handleIncomingReverseOpen(message: AdbMessage) {
+        val destination = extractOpenDestination(message) ?: run {
+            adbWriter.writeClose(REVERSE_LISTENER_ID, message.arg0)
+            return
+        }
+
+        val target = parseReverseTcpTarget(destination) ?: run {
+            adbWriter.writeClose(REVERSE_LISTENER_ID, message.arg0)
+            return
+        }
+
+        val localSocket = runCatching { Socket(target.host, target.port) }.getOrElse {
+            adbWriter.writeClose(REVERSE_LISTENER_ID, message.arg0)
+            return
+        }
+
+        val localId = newId()
+        messageQueue.startListening(localId)
+        val initialReceiveWindow = if (delayedAckEnabled) Constants.INITIAL_DELAYED_ACK_BYTES else null
+        adbWriter.writeOkay(localId, message.arg0, initialReceiveWindow)
+
+        val initialAvailableSendBytes = if (delayedAckEnabled) {
+            message.arg1.toLong().coerceAtLeast(0)
+        } else {
+            0L
+        }
+        val adbStream = AdbStreamImpl(
+            messageQueue = messageQueue,
+            adbWriter = adbWriter,
+            maxPayloadSize = maxPayloadSize,
+            localId = localId,
+            remoteId = message.arg0,
+            delayedAckEnabled = delayedAckEnabled,
+            initialAvailableSendBytes = initialAvailableSendBytes,
+        )
+        val socketSource = localSocket.getInputStream().source()
+        val socketSink = localSocket.getOutputStream().sink().buffer()
+
+        val localToDevice = thread(name = "dadb-reverse-local-to-device") {
+            try {
+                StreamForwarder.transfer(socketSource, adbStream.sink)
+            } finally {
+                reverseSessionThreads.remove(Thread.currentThread())
+            }
+        }
+        reverseSessionThreads.add(localToDevice)
+
+        val deviceToLocal = thread(name = "dadb-reverse-device-to-local") {
+            try {
+                StreamForwarder.transfer(adbStream.source, socketSink)
+            } finally {
+                runCatching { adbStream.close() }
+                runCatching { localSocket.close() }
+                localToDevice.interrupt()
+                reverseSessionThreads.remove(Thread.currentThread())
+            }
+        }
+        reverseSessionThreads.add(deviceToLocal)
+    }
+
+    private fun extractOpenDestination(message: AdbMessage): String? {
+        if (message.payloadLength <= 0) {
+            return null
+        }
+
+        val endExclusive =
+            if (message.payload[message.payloadLength - 1].toInt() == 0) {
+                message.payloadLength - 1
+            } else {
+                message.payloadLength
+            }
+
+        if (endExclusive <= 0) {
+            return null
+        }
+
+        return String(message.payload, 0, endExclusive)
+    }
     companion object {
+        private const val REVERSE_LISTENER_ID = 0
 
         fun connect(socket: Socket, keyPair: AdbKeyPair? = null): AdbConnection {
             val source = socket.source()
@@ -106,7 +246,7 @@ internal class AdbConnection internal constructor(
             connectMaxData: Int = Constants.CONNECT_MAXDATA,
             tlsUpgradableTransport: TlsUpgradableAdbTransport? = null,
         ): AdbConnection {
-            val adbReader = AdbReader(source)
+            val adbReader = AdbReader(source, maxPayloadSize = Constants.MAX_PAYLOAD_V1)
             val adbWriter = AdbWriter(sink)
 
             try {
@@ -140,7 +280,7 @@ internal class AdbConnection internal constructor(
                 currentWriter.writeStls(message.arg0)
                 tlsUpgradableTransport.upgradeToTls(message.arg0)
                 tlsUpgraded = true
-                currentReader = AdbReader(tlsUpgradableTransport.source)
+                currentReader = AdbReader(tlsUpgradableTransport.source, maxPayloadSize = Constants.MAX_PAYLOAD_V1)
                 currentWriter = AdbWriter(tlsUpgradableTransport.sink)
                 message = currentReader.readMessage()
             }
@@ -162,21 +302,40 @@ internal class AdbConnection internal constructor(
             if (message.command != Constants.CMD_CNXN) throw IOException("Connection failed: $message")
 
             val connectionString = parseConnectionString(String(message.payload))
-            val version = message.arg0
-            val maxPayloadSize = message.arg1
+            val peerFeatures = connectionString.features
+            val version = minOf(message.arg0, Constants.CONNECT_VERSION)
+            val peerMaxPayloadSize = message.arg1
+            if (peerMaxPayloadSize <= 0) {
+                throw IOException("Peer maxdata must be > 0: $peerMaxPayloadSize")
+            }
+            val maxPayloadSize = minOf(peerMaxPayloadSize, connectMaxData)
+                    .coerceAtLeast(1)
+                    .coerceAtMost(Constants.CONNECT_MAXDATA)
+            currentReader.setMaxPayloadSize(maxPayloadSize)
+            currentWriter.updateProtocolVersion(version)
 
-            return AdbConnection(currentReader, currentWriter, closeable, connectionString.features, version, maxPayloadSize, tlsUpgraded)
+            return AdbConnection(currentReader, currentWriter, closeable, peerFeatures, version, maxPayloadSize, tlsUpgraded)
         }
 
         // ie: "device::ro.product.name=sdk_gphone_x86;ro.product.model=Android SDK built for x86;ro.product.device=generic_x86;features=fixed_push_symlink_timestamp,apex,fixed_push_mkdir,stat_v2,abb_exec,cmd,abb,shell_v2"
         private fun parseConnectionString(connectionString: String): ConnectionString {
             val keyValues = connectionString.substringAfter("device::")
                     .split(";")
-                    .map { it.split("=") }
-                    .mapNotNull { if (it.size != 2) null else it[0] to it[1] }
+                    .mapNotNull { property ->
+                        val delimiter = property.indexOf('=')
+                        if (delimiter <= 0 || delimiter == property.lastIndex) {
+                            null
+                        } else {
+                            property.substring(0, delimiter) to property.substring(delimiter + 1)
+                        }
+                    }
                     .toMap()
-            if ("features" !in keyValues) throw IOException("Failed to parse features from connection string: $connectionString")
-            val features = keyValues.getValue("features").split(",").toSet()
+            val features = keyValues["features"]
+                    ?.split(",")
+                    ?.map { it.trim() }
+                    ?.filter { it.isNotEmpty() }
+                    ?.toSet()
+                    ?: emptySet()
             return ConnectionString(features)
         }
     }

--- a/dadb/src/main/kotlin/dadb/AdbConnection.kt
+++ b/dadb/src/main/kotlin/dadb/AdbConnection.kt
@@ -22,7 +22,6 @@ import okio.Source
 import okio.sink
 import okio.source
 import org.jetbrains.annotations.TestOnly
-import java.io.Closeable
 import java.io.IOException
 import java.net.Socket
 import java.util.*
@@ -30,7 +29,7 @@ import java.util.*
 internal class AdbConnection internal constructor(
         adbReader: AdbReader,
         private val adbWriter: AdbWriter,
-        private val closeable: Closeable?,
+        private val closeable: AutoCloseable?,
         private val supportedFeatures: Set<String>,
         private val version: Int,
         private val maxPayloadSize: Int
@@ -83,12 +82,28 @@ internal class AdbConnection internal constructor(
             return connect(source, sink, keyPair, socket)
         }
 
-        private fun connect(source: Source, sink: Sink, keyPair: AdbKeyPair? = null, closeable: Closeable? = null): AdbConnection {
+        fun connect(transport: AdbTransport, keyPair: AdbKeyPair? = null): AdbConnection {
+            return connect(
+                transport.source,
+                transport.sink,
+                keyPair,
+                closeable = transport,
+                connectMaxData = transport.connectMaxData,
+            )
+        }
+
+        private fun connect(
+            source: Source,
+            sink: Sink,
+            keyPair: AdbKeyPair? = null,
+            closeable: AutoCloseable? = null,
+            connectMaxData: Int = Constants.CONNECT_MAXDATA,
+        ): AdbConnection {
             val adbReader = AdbReader(source)
             val adbWriter = AdbWriter(sink)
 
             try {
-                return connect(adbReader, adbWriter, keyPair, closeable)
+                return connect(adbReader, adbWriter, keyPair, closeable, connectMaxData)
             } catch (t: Throwable) {
                 adbReader.close()
                 adbWriter.close()
@@ -96,8 +111,14 @@ internal class AdbConnection internal constructor(
             }
         }
 
-        private fun connect(adbReader: AdbReader, adbWriter: AdbWriter, keyPair: AdbKeyPair?, closeable: Closeable?): AdbConnection {
-            adbWriter.writeConnect()
+        private fun connect(
+            adbReader: AdbReader,
+            adbWriter: AdbWriter,
+            keyPair: AdbKeyPair?,
+            closeable: AutoCloseable?,
+            connectMaxData: Int,
+        ): AdbConnection {
+            adbWriter.writeConnect(connectMaxData)
 
             var message = adbReader.readMessage()
 

--- a/dadb/src/main/kotlin/dadb/AdbConnection.kt
+++ b/dadb/src/main/kotlin/dadb/AdbConnection.kt
@@ -32,7 +32,8 @@ internal class AdbConnection internal constructor(
         private val closeable: AutoCloseable?,
         private val supportedFeatures: Set<String>,
         private val version: Int,
-        private val maxPayloadSize: Int
+        private val maxPayloadSize: Int,
+        private val tlsUpgraded: Boolean,
 ) : AutoCloseable {
 
     private val random = Random()
@@ -55,6 +56,10 @@ internal class AdbConnection internal constructor(
 
     fun supportsFeature(feature: String): Boolean {
         return supportedFeatures.contains(feature)
+    }
+
+    fun isTlsConnection(): Boolean {
+        return tlsUpgraded
     }
 
     private fun newId(): Int {
@@ -89,6 +94,7 @@ internal class AdbConnection internal constructor(
                 keyPair,
                 closeable = transport,
                 connectMaxData = transport.connectMaxData,
+                tlsUpgradableTransport = transport as? TlsUpgradableAdbTransport,
             )
         }
 
@@ -98,12 +104,13 @@ internal class AdbConnection internal constructor(
             keyPair: AdbKeyPair? = null,
             closeable: AutoCloseable? = null,
             connectMaxData: Int = Constants.CONNECT_MAXDATA,
+            tlsUpgradableTransport: TlsUpgradableAdbTransport? = null,
         ): AdbConnection {
             val adbReader = AdbReader(source)
             val adbWriter = AdbWriter(sink)
 
             try {
-                return connect(adbReader, adbWriter, keyPair, closeable, connectMaxData)
+                return connect(adbReader, adbWriter, keyPair, closeable, connectMaxData, tlsUpgradableTransport)
             } catch (t: Throwable) {
                 adbReader.close()
                 adbWriter.close()
@@ -117,22 +124,38 @@ internal class AdbConnection internal constructor(
             keyPair: AdbKeyPair?,
             closeable: AutoCloseable?,
             connectMaxData: Int,
+            tlsUpgradableTransport: TlsUpgradableAdbTransport?,
         ): AdbConnection {
-            adbWriter.writeConnect(connectMaxData)
+            var currentReader = adbReader
+            var currentWriter = adbWriter
+            var tlsUpgraded = false
+            currentWriter.writeConnect(connectMaxData)
 
-            var message = adbReader.readMessage()
+            var message = currentReader.readMessage()
+
+            if (message.command == Constants.CMD_STLS) {
+                checkNotNull(tlsUpgradableTransport) {
+                    "TLS upgrade requested by device, but transport does not support STLS/TLS upgrade"
+                }
+                currentWriter.writeStls(message.arg0)
+                tlsUpgradableTransport.upgradeToTls(message.arg0)
+                tlsUpgraded = true
+                currentReader = AdbReader(tlsUpgradableTransport.source)
+                currentWriter = AdbWriter(tlsUpgradableTransport.sink)
+                message = currentReader.readMessage()
+            }
 
             if (message.command == Constants.CMD_AUTH) {
                 checkNotNull(keyPair) { "Authentication required but no KeyPair provided" }
                 check(message.arg0 == Constants.AUTH_TYPE_TOKEN) { "Unsupported auth type: $message" }
 
                 val signature = keyPair.signPayload(message)
-                adbWriter.writeAuth(Constants.AUTH_TYPE_SIGNATURE, signature)
+                currentWriter.writeAuth(Constants.AUTH_TYPE_SIGNATURE, signature)
 
-                message = adbReader.readMessage()
+                message = currentReader.readMessage()
                 if (message.command == Constants.CMD_AUTH) {
-                    adbWriter.writeAuth(Constants.AUTH_TYPE_RSA_PUBLIC, keyPair.publicKeyBytes)
-                    message = adbReader.readMessage()
+                    currentWriter.writeAuth(Constants.AUTH_TYPE_RSA_PUBLIC, keyPair.publicKeyBytes)
+                    message = currentReader.readMessage()
                 }
             }
 
@@ -142,7 +165,7 @@ internal class AdbConnection internal constructor(
             val version = message.arg0
             val maxPayloadSize = message.arg1
 
-            return AdbConnection(adbReader, adbWriter, closeable, connectionString.features, version, maxPayloadSize)
+            return AdbConnection(currentReader, currentWriter, closeable, connectionString.features, version, maxPayloadSize, tlsUpgraded)
         }
 
         // ie: "device::ro.product.name=sdk_gphone_x86;ro.product.model=Android SDK built for x86;ro.product.device=generic_x86;features=fixed_push_symlink_timestamp,apex,fixed_push_mkdir,stat_v2,abb_exec,cmd,abb,shell_v2"

--- a/dadb/src/main/kotlin/dadb/AdbConnection.kt
+++ b/dadb/src/main/kotlin/dadb/AdbConnection.kt
@@ -227,7 +227,7 @@ internal class AdbConnection internal constructor(
             return connect(source, sink, keyPair, socket)
         }
 
-        fun connect(transport: AdbTransport, keyPair: AdbKeyPair? = null): AdbConnection {
+        fun connect(transport: AdbTransport, keyPair: AdbKeyPair? = null, features: Set<String> = Constants.CONNECT_FEATURES.toSet()): AdbConnection {
             return connect(
                 transport.source,
                 transport.sink,
@@ -235,6 +235,7 @@ internal class AdbConnection internal constructor(
                 closeable = transport,
                 connectMaxData = transport.connectMaxData,
                 tlsUpgradableTransport = transport as? TlsUpgradableAdbTransport,
+                features = features,
             )
         }
 
@@ -245,12 +246,13 @@ internal class AdbConnection internal constructor(
             closeable: AutoCloseable? = null,
             connectMaxData: Int = Constants.CONNECT_MAXDATA,
             tlsUpgradableTransport: TlsUpgradableAdbTransport? = null,
+            features: Set<String> = Constants.CONNECT_FEATURES.toSet(),
         ): AdbConnection {
             val adbReader = AdbReader(source, maxPayloadSize = Constants.MAX_PAYLOAD_V1)
             val adbWriter = AdbWriter(sink)
 
             try {
-                return connect(adbReader, adbWriter, keyPair, closeable, connectMaxData, tlsUpgradableTransport)
+                return connect(adbReader, adbWriter, keyPair, closeable, connectMaxData, tlsUpgradableTransport, features)
             } catch (t: Throwable) {
                 adbReader.close()
                 adbWriter.close()
@@ -265,11 +267,13 @@ internal class AdbConnection internal constructor(
             closeable: AutoCloseable?,
             connectMaxData: Int,
             tlsUpgradableTransport: TlsUpgradableAdbTransport?,
+            features: Set<String> = Constants.CONNECT_FEATURES.toSet(),
         ): AdbConnection {
             var currentReader = adbReader
             var currentWriter = adbWriter
             var tlsUpgraded = false
-            currentWriter.writeConnect(connectMaxData)
+            val connectPayload = "host::features=${features.joinToString(",")}".toByteArray()
+            currentWriter.writeConnect(connectMaxData, connectPayload)
 
             var message = currentReader.readMessage()
 

--- a/dadb/src/main/kotlin/dadb/AdbConnection.kt
+++ b/dadb/src/main/kotlin/dadb/AdbConnection.kt
@@ -35,6 +35,7 @@ internal class AdbConnection internal constructor(
         private val adbWriter: AdbWriter,
         private val closeable: AutoCloseable?,
         private val supportedFeatures: Set<String>,
+        private val delayedAckEnabled: Boolean,
         private val version: Int,
         private val maxPayloadSize: Int,
         private val tlsUpgraded: Boolean,
@@ -43,7 +44,6 @@ internal class AdbConnection internal constructor(
     private val random = Random()
     private val messageQueue = AdbMessageQueue(adbReader)
     private val reverseSessionThreads = ConcurrentLinkedQueue<Thread>()
-    private val delayedAckEnabled = supportedFeatures.contains(Constants.FEATURE_DELAYED_ACK)
 
     @Volatile
     private var reverseThread: Thread? = null
@@ -307,6 +307,9 @@ internal class AdbConnection internal constructor(
 
             val connectionString = parseConnectionString(String(message.payload))
             val peerFeatures = connectionString.features
+            val delayedAckEnabled =
+                Constants.FEATURE_DELAYED_ACK in features &&
+                    Constants.FEATURE_DELAYED_ACK in peerFeatures
             val version = minOf(message.arg0, Constants.CONNECT_VERSION)
             val peerMaxPayloadSize = message.arg1
             if (peerMaxPayloadSize <= 0) {
@@ -318,7 +321,16 @@ internal class AdbConnection internal constructor(
             currentReader.setMaxPayloadSize(maxPayloadSize)
             currentWriter.updateProtocolVersion(version)
 
-            return AdbConnection(currentReader, currentWriter, closeable, peerFeatures, version, maxPayloadSize, tlsUpgraded)
+            return AdbConnection(
+                currentReader,
+                currentWriter,
+                closeable,
+                peerFeatures,
+                delayedAckEnabled,
+                version,
+                maxPayloadSize,
+                tlsUpgraded,
+            )
         }
 
         // ie: "device::ro.product.name=sdk_gphone_x86;ro.product.model=Android SDK built for x86;ro.product.device=generic_x86;features=fixed_push_symlink_timestamp,apex,fixed_push_mkdir,stat_v2,abb_exec,cmd,abb,shell_v2"

--- a/dadb/src/main/kotlin/dadb/AdbKeyPair.kt
+++ b/dadb/src/main/kotlin/dadb/AdbKeyPair.kt
@@ -27,12 +27,10 @@ import java.security.interfaces.RSAPublicKey
 import java.util.*
 import javax.crypto.Cipher
 
-
 class AdbKeyPair(
-        private val privateKey: PrivateKey,
-        internal val publicKeyBytes: ByteArray
+    private val privateKey: PrivateKey,
+    internal val publicKeyBytes: ByteArray,
 ) {
-
     /**
      * Returns the private key backing this ADB identity.
      *
@@ -57,32 +55,250 @@ class AdbKeyPair(
     }
 
     companion object {
-
+        private const val DEFAULT_PUBLIC_KEY_OWNER = "app@screen-remote"
         private const val KEY_LENGTH_BITS = 2048
         private const val KEY_LENGTH_BYTES = KEY_LENGTH_BITS / 8
         private const val KEY_LENGTH_WORDS = KEY_LENGTH_BYTES / 4
 
-        private val SIGNATURE_PADDING = ubyteArrayOf(
-            0x00u, 0x01u, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu,
-            0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu,
-            0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu,
-            0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu,
-            0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu,
-            0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu,
-            0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu,
-            0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu,
-            0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu,
-            0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu,
-            0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu,
-            0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu,
-            0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu,
-            0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu,
-            0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu,
-            0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu,
-            0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0x00u,
-            0x30u, 0x21u, 0x30u, 0x09u, 0x06u, 0x05u, 0x2bu, 0x0eu, 0x03u, 0x02u, 0x1au, 0x05u, 0x00u,
-            0x04u, 0x14u
-        ).toByteArray()
+        private val SIGNATURE_PADDING =
+            ubyteArrayOf(
+                0x00u,
+                0x01u,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0xffu,
+                0x00u,
+                0x30u,
+                0x21u,
+                0x30u,
+                0x09u,
+                0x06u,
+                0x05u,
+                0x2bu,
+                0x0eu,
+                0x03u,
+                0x02u,
+                0x1au,
+                0x05u,
+                0x00u,
+                0x04u,
+                0x14u,
+            ).toByteArray()
 
         @JvmStatic
         fun readDefault(): AdbKeyPair {
@@ -98,23 +314,33 @@ class AdbKeyPair(
 
         @JvmStatic
         @JvmOverloads
-        fun read(privateKeyFile: File, publicKeyFile: File? = null): AdbKeyPair {
+        fun read(
+            privateKeyFile: File,
+            publicKeyFile: File? = null,
+        ): AdbKeyPair {
             val privateKey = PKCS8.parse(privateKeyFile.readBytes())
-            val publicKeyBytes = if (publicKeyFile?.exists() == true) {
-                readAdbPublicKey(publicKeyFile)
-            } else {
-                ByteArray(0)
-            }
+            val publicKeyBytes =
+                if (publicKeyFile?.exists() == true) {
+                    readAdbPublicKey(publicKeyFile)
+                } else {
+                    ByteArray(0)
+                }
 
             return AdbKeyPair(privateKey, publicKeyBytes)
         }
 
         @JvmStatic
-        fun generate(privateKeyFile: File, publicKeyFile: File) {
-            val keyPair = KeyPairGenerator.getInstance("RSA").let {
-                it.initialize(KEY_LENGTH_BITS)
-                it.genKeyPair()
-            }
+        @JvmOverloads
+        fun generate(
+            privateKeyFile: File,
+            publicKeyFile: File,
+            publicKeyOwner: String = DEFAULT_PUBLIC_KEY_OWNER,
+        ) {
+            val keyPair =
+                KeyPairGenerator.getInstance("RSA").let {
+                    it.initialize(KEY_LENGTH_BITS)
+                    it.genKeyPair()
+                }
 
             privateKeyFile.absoluteFile.parentFile?.mkdirs()
             publicKeyFile.absoluteFile.parentFile?.mkdirs()
@@ -130,9 +356,12 @@ class AdbKeyPair(
                 val base64 = Base64.getEncoder()
                 val bytes = convertRsaPublicKeyToAdbFormat(keyPair.public as RSAPublicKey)
                 out.write(base64.encodeToString(bytes))
-                out.write(" unknown@unknown")
+                out.write(" ${normalizePublicKeyOwner(publicKeyOwner)}")
             }
         }
+
+        private fun normalizePublicKeyOwner(publicKeyOwner: String): String =
+            publicKeyOwner.trim().ifBlank { DEFAULT_PUBLIC_KEY_OWNER }
 
         private fun readAdbPublicKey(file: File): ByteArray {
             val bytes = file.readBytes()
@@ -156,7 +385,7 @@ class AdbKeyPair(
              * } RSAPublicKey;
              */
 
-            /* ------ This part is a Java-ified version of RSA_to_RSAPublicKey from adb_host_auth.c ------ */
+            // ------ This part is a Java-ified version of RSA_to_RSAPublicKey from adb_host_auth.c ------
             val r32: BigInteger
             val r: BigInteger
             var rr: BigInteger
@@ -183,7 +412,7 @@ class AdbKeyPair(
                 myN[i] = rem.toInt()
             }
 
-            /* ------------------------------------------------------------------------------------------- */
+            // -------------------------------------------------------------------------------------------
             val bbuf: ByteBuffer = ByteBuffer.allocate(524).order(ByteOrder.LITTLE_ENDIAN)
             bbuf.putInt(KEY_LENGTH_WORDS)
             bbuf.putInt(n0inv.negate().toInt())

--- a/dadb/src/main/kotlin/dadb/AdbKeyPair.kt
+++ b/dadb/src/main/kotlin/dadb/AdbKeyPair.kt
@@ -33,6 +33,22 @@ class AdbKeyPair(
         internal val publicKeyBytes: ByteArray
 ) {
 
+    /**
+     * Returns the private key backing this ADB identity.
+     *
+     * Exposing this avoids reflection for higher-level TLS and pairing helpers that need to build
+     * certificates or socket contexts from the same key material.
+     */
+    fun privateKey(): PrivateKey = privateKey
+
+    /**
+     * Returns the RSA public key in Android ADB wire format, including the trailing NUL byte.
+     *
+     * Exposing this avoids reflection for higher-level pairing and wireless-debugging helpers
+     * that need to send PEER_INFO without leaking the private key.
+     */
+    fun adbPublicKey(): ByteArray = publicKeyBytes.copyOf()
+
     internal fun signPayload(message: AdbMessage): ByteArray {
         val cipher = Cipher.getInstance("RSA/ECB/NoPadding")
         cipher.init(Cipher.ENCRYPT_MODE, privateKey)

--- a/dadb/src/main/kotlin/dadb/AdbMessage.kt
+++ b/dadb/src/main/kotlin/dadb/AdbMessage.kt
@@ -80,6 +80,7 @@ internal class AdbMessage(
     private fun commandStr() = when (command) {
         Constants.CMD_AUTH -> "AUTH";
         Constants.CMD_CNXN -> "CNXN";
+        Constants.CMD_STLS -> "STLS";
         Constants.CMD_OPEN -> "OPEN";
         Constants.CMD_OKAY -> "OKAY";
         Constants.CMD_CLSE -> "CLSE";

--- a/dadb/src/main/kotlin/dadb/AdbReader.kt
+++ b/dadb/src/main/kotlin/dadb/AdbReader.kt
@@ -19,10 +19,20 @@ package dadb
 
 import okio.Source
 import okio.buffer
+import java.io.IOException
 
-internal class AdbReader(source: Source) : AutoCloseable {
+internal class AdbReader(
+    source: Source,
+    maxPayloadSize: Int = Constants.CONNECT_MAXDATA,
+) : AutoCloseable {
 
     private val bufferedSource = source.buffer()
+    @Volatile
+    private var maxPayloadSize = maxPayloadSize.coerceAtLeast(0).coerceAtMost(Constants.CONNECT_MAXDATA)
+
+    fun setMaxPayloadSize(maxPayloadSize: Int) {
+        this.maxPayloadSize = maxPayloadSize.coerceAtLeast(0).coerceAtMost(Constants.CONNECT_MAXDATA)
+    }
 
     fun readMessage(): AdbMessage {
         synchronized(bufferedSource) {
@@ -31,8 +41,15 @@ internal class AdbReader(source: Source) : AutoCloseable {
                 val arg0 = readIntLe()
                 val arg1 = readIntLe()
                 val payloadLength = readIntLe()
+                if (payloadLength < 0 || payloadLength > maxPayloadSize) {
+                    throw IOException("Invalid ADB payload length: $payloadLength (max=$maxPayloadSize)")
+                }
                 val checksum = readIntLe()
                 val magic = readIntLe()
+                val expectedMagic = command.inv()
+                if (magic != expectedMagic) {
+                    throw IOException("Invalid ADB magic: expected=$expectedMagic actual=$magic command=$command")
+                }
                 val payload = readByteArray(payloadLength.toLong())
                 return AdbMessage(command, arg0, arg1, payloadLength, checksum, magic, payload).also {
                     log { "(${Thread.currentThread().name}) < $it" }

--- a/dadb/src/main/kotlin/dadb/AdbReverse.kt
+++ b/dadb/src/main/kotlin/dadb/AdbReverse.kt
@@ -1,0 +1,158 @@
+package dadb
+
+import java.io.IOException
+
+data class AdbReverseRule(
+    val device: String,
+    val host: String,
+)
+
+internal enum class AdbServiceStatus {
+    OKAY,
+    FAIL,
+    UNKNOWN,
+}
+
+internal data class AdbServiceResponse(
+    val status: AdbServiceStatus,
+    val payload: String,
+)
+
+internal fun buildReverseForwardDestination(
+    device: String,
+    host: String,
+    noRebind: Boolean = false,
+): String {
+    require(device.isNotBlank()) { "device must not be blank" }
+    require(host.isNotBlank()) { "host must not be blank" }
+    val prefix = if (noRebind) "reverse:forward:norebind:" else "reverse:forward:"
+    return "$prefix$device;$host"
+}
+
+internal fun buildReverseKillDestination(device: String): String {
+    require(device.isNotBlank()) { "device must not be blank" }
+    return "reverse:killforward:$device"
+}
+
+internal fun buildReverseKillAllDestination(): String = "reverse:killforward-all"
+
+internal fun buildReverseListDestination(): String = "reverse:list-forward"
+
+internal fun parseAdbServiceResponse(raw: String): AdbServiceResponse {
+    return when {
+        raw.startsWith("OKAY") -> {
+            AdbServiceResponse(
+                status = AdbServiceStatus.OKAY,
+                payload = decodeProtocolStringOrRaw(raw.removePrefix("OKAY")),
+            )
+        }
+
+        raw.startsWith("FAIL") -> {
+            AdbServiceResponse(
+                status = AdbServiceStatus.FAIL,
+                payload = decodeProtocolStringOrRaw(raw.removePrefix("FAIL")),
+            )
+        }
+
+        else -> {
+            AdbServiceResponse(
+                status = AdbServiceStatus.UNKNOWN,
+                payload = decodeProtocolStringOrRaw(raw),
+            )
+        }
+    }
+}
+
+internal fun parseReverseListOutput(output: String): List<AdbReverseRule> {
+    return output
+        .lineSequence()
+        .map { it.trim() }
+        .filter { it.isNotBlank() }
+        .mapNotNull { line ->
+            val fields = line.split(Regex("\\s+"))
+            when {
+                fields.size >= 3 -> AdbReverseRule(
+                    device = fields[fields.lastIndex - 1],
+                    host = fields.last(),
+                )
+
+                fields.size == 2 -> AdbReverseRule(
+                    device = fields[0],
+                    host = fields[1],
+                )
+
+                else -> null
+            }
+        }
+        .toList()
+}
+
+internal fun Dadb.executeAdbService(destination: String): String {
+    return open(destination).use { stream ->
+        val raw = stream.source.readUtf8()
+        val response = parseAdbServiceResponse(raw)
+        if (response.status == AdbServiceStatus.FAIL) {
+            throw IOException("ADB service failed for '$destination': ${response.payload}")
+        }
+        response.payload
+    }
+}
+
+internal data class ReverseTcpTarget(
+    val host: String,
+    val port: Int,
+)
+
+internal fun parseReverseTcpTarget(destination: String): ReverseTcpTarget? {
+    if (!destination.startsWith("tcp:")) {
+        return null
+    }
+
+    val raw = destination.removePrefix("tcp:")
+    if (raw.isBlank()) {
+        return null
+    }
+
+    val segments = raw.split(':')
+    return when (segments.size) {
+        1 -> {
+            val port = segments[0].toIntOrNull() ?: return null
+            if (port !in 1..65535) {
+                return null
+            }
+            ReverseTcpTarget(host = "127.0.0.1", port = port)
+        }
+
+        2 -> {
+            val host = segments[0].ifBlank { return null }
+            val port = segments[1].toIntOrNull() ?: return null
+            if (port !in 1..65535) {
+                return null
+            }
+            ReverseTcpTarget(host = host, port = port)
+        }
+
+        else -> null
+    }
+}
+
+internal fun requireSupportedReverseHostDestination(destination: String) {
+    require(parseReverseTcpTarget(destination) != null) {
+        "Direct dadb reverse currently supports only tcp:<port> or tcp:<host>:<port> host destinations"
+    }
+}
+
+private fun decodeProtocolStringOrRaw(content: String): String {
+    if (content.length < 4) {
+        return content
+    }
+
+    val header = content.substring(0, 4)
+    val length = header.toIntOrNull(16) ?: return content
+    val payloadEnd = 4 + length
+    if (content.length < payloadEnd) {
+        return content
+    }
+
+    return content.substring(4, payloadEnd)
+}

--- a/dadb/src/main/kotlin/dadb/AdbStream.kt
+++ b/dadb/src/main/kotlin/dadb/AdbStream.kt
@@ -33,7 +33,9 @@ internal class AdbStreamImpl internal constructor(
         private val adbWriter: AdbWriter,
         private val maxPayloadSize: Int,
         private val localId: Int,
-        private val remoteId: Int
+        private val remoteId: Int,
+        private val delayedAckEnabled: Boolean = false,
+        private val initialAvailableSendBytes: Long = 0,
 ) : AdbStream {
 
     private var isClosed = false
@@ -47,17 +49,26 @@ internal class AdbStreamImpl internal constructor(
             val message = message() ?: return -1
 
             val bytesRemaining = message.payloadLength - bytesRead
-            val bytesToRead = Math.min(byteCount.toInt(), bytesRemaining)
+            val bytesToRead = byteCount
+                .coerceAtMost(Int.MAX_VALUE.toLong())
+                .toInt()
+                .coerceAtMost(bytesRemaining)
 
             sink.write(message.payload, bytesRead, bytesToRead)
 
             bytesRead += bytesToRead
 
+            if (delayedAckEnabled && bytesToRead > 0) {
+                adbWriter.writeOkay(localId, remoteId, bytesToRead)
+            }
+
             check(bytesRead <= message.payloadLength)
 
             if (bytesRead == message.payloadLength) {
                 this.message = null
-                adbWriter.writeOkay(localId, remoteId)
+                if (!delayedAckEnabled) {
+                    adbWriter.writeOkay(localId, remoteId)
+                }
             }
 
             return bytesToRead.toLong()
@@ -79,19 +90,21 @@ internal class AdbStreamImpl internal constructor(
     override val sink = object : Sink {
 
         private val buffer = ByteBuffer.allocate(maxPayloadSize)
+        private var availableSendBytes = initialAvailableSendBytes
 
         override fun write(source: Buffer, byteCount: Long) {
             var remainingBytes = byteCount
             while (true) {
-                remainingBytes -= writeToBuffer(source, byteCount)
+                remainingBytes -= writeToBuffer(source, remainingBytes)
                 if (remainingBytes == 0L) return
                 check(remainingBytes > 0L)
             }
         }
 
         private fun writeToBuffer(source: BufferedSource, byteCount: Long): Int {
-            val bytesToWrite = min(buffer.remaining(), byteCount.toInt())
+            val bytesToWrite = min(buffer.remaining(), byteCount.coerceAtMost(Int.MAX_VALUE.toLong()).toInt())
             val bytesWritten = source.read(buffer.array(), buffer.position(), bytesToWrite)
+            if (bytesWritten < 0) throw java.io.EOFException("EOF while writing ADB stream")
 
             // Cast to prevent NoSuchMethodError when mixing Java versions
             // Learn more: https://www.morling.dev/blog/bytebuffer-and-the-dreaded-nosuchmethoderror
@@ -102,11 +115,32 @@ internal class AdbStreamImpl internal constructor(
         }
 
         override fun flush() {
-            adbWriter.writeWrite(localId, remoteId, buffer.array(), 0, buffer.position())
+            val payloadLength = buffer.position()
+            if (payloadLength == 0) return
+            if (delayedAckEnabled) {
+                var offset = 0
+                while (offset < payloadLength) {
+                    while (availableSendBytes <= 0) {
+                        availableSendBytes += awaitAckBytes().toLong()
+                    }
+                    val chunkLength = min(
+                        payloadLength - offset,
+                        availableSendBytes.coerceAtMost(Int.MAX_VALUE.toLong()).toInt(),
+                    )
+                    adbWriter.writeWrite(localId, remoteId, buffer.array(), offset, chunkLength)
+                    availableSendBytes -= chunkLength.toLong()
+                    offset += chunkLength
+                }
+            } else {
+                adbWriter.writeWrite(localId, remoteId, buffer.array(), 0, payloadLength)
+            }
 
             // Cast to prevent NoSuchMethodError when mixing Java versions
             // Learn more: https://www.morling.dev/blog/bytebuffer-and-the-dreaded-nosuchmethoderror
             (buffer as java.nio.Buffer).clear()
+            if (!delayedAckEnabled && nextMessage(Constants.CMD_OKAY) == null) {
+                throw IOException("ADB stream closed before OKAY for localId: ${localId.toString(16)}")
+            }
         }
 
         override fun close() {}
@@ -114,21 +148,36 @@ internal class AdbStreamImpl internal constructor(
         override fun timeout() = Timeout.NONE
     }.buffer()
 
+    private fun awaitAckBytes(): Int {
+        val message = nextMessage(Constants.CMD_OKAY)
+            ?: throw IOException("ADB stream closed before delayed ACK for localId: ${localId.toString(16)}")
+        val ackBytes = Constants.decodeOkayAckBytes(message, delayedAckEnabled = true)
+        require(ackBytes >= 0) { "Delayed ACK bytes must be >= 0: $ackBytes" }
+        return ackBytes
+    }
+
     private fun nextMessage(command: Int): AdbMessage? {
         return try {
             messageQueue.take(localId, command)
         } catch (e: IOException) {
-            close()
+            close(sendClose = false)
             return null
         }
     }
 
     override fun close() {
+        close(sendClose = true)
+    }
+
+    private fun close(sendClose: Boolean) {
         if (isClosed) return
         isClosed = true
-
-        adbWriter.writeClose(localId, remoteId)
-
-        messageQueue.stopListening(localId)
+        try {
+            if (sendClose) {
+                adbWriter.writeClose(localId, remoteId)
+            }
+        } finally {
+            messageQueue.stopListening(localId)
+        }
     }
 }

--- a/dadb/src/main/kotlin/dadb/AdbSync.kt
+++ b/dadb/src/main/kotlin/dadb/AdbSync.kt
@@ -22,93 +22,461 @@ import java.io.IOException
 import java.nio.charset.StandardCharsets
 import kotlin.jvm.Throws
 
-internal const val LIST = "LIST"
-internal const val RECV = "RECV"
-internal const val SEND = "SEND"
 internal const val STAT = "STAT"
+internal const val STAT_V2 = "STA2"
+internal const val LSTAT_V2 = "LST2"
+internal const val LIST = "LIST"
+internal const val LIST_V2 = "LIS2"
+internal const val DENT = "DENT"
+internal const val DENT_V2 = "DNT2"
+internal const val SEND = "SEND"
+internal const val SEND_V2 = "SND2"
+internal const val RECV = "RECV"
+internal const val RECV_V2 = "RCV2"
 internal const val DATA = "DATA"
 internal const val DONE = "DONE"
 internal const val OKAY = "OKAY"
 internal const val QUIT = "QUIT"
 internal const val FAIL = "FAIL"
+internal const val FEATURE_STAT_V2 = "stat_v2"
+internal const val FEATURE_LS_V2 = "ls_v2"
+internal const val FEATURE_SENDRECV_V2 = "sendrecv_v2"
+internal const val SYNC_PATH_MAX = 1024
+internal const val SYNC_DATA_MAX = 64 * 1024
+internal const val SYNC_NAME_MAX = 255
+internal const val LIST_V1_DONE_TAIL_BYTES = 16L
+internal const val LIST_V2_DONE_TAIL_BYTES = 72L
 
-internal val SYNC_IDS = setOf(LIST, RECV, SEND, STAT, DATA, DONE, OKAY, QUIT, FAIL)
+internal val SYNC_IDS = setOf(
+    STAT,
+    STAT_V2,
+    LSTAT_V2,
+    LIST,
+    LIST_V2,
+    DENT,
+    DENT_V2,
+    SEND,
+    SEND_V2,
+    RECV,
+    RECV_V2,
+    DATA,
+    DONE,
+    OKAY,
+    QUIT,
+    FAIL,
+)
 
 private class Packet(val id: String, val arg: Int)
 
+private class DentV2Fields(
+    val errorCode: Int,
+    val dev: Long,
+    val ino: Long,
+    val mode: Int,
+    val nlink: Int,
+    val uid: Int,
+    val gid: Int,
+    val size: Long,
+    val atimeSec: Long,
+    val mtimeSec: Long,
+    val ctimeSec: Long,
+    val name: String,
+)
+
 class AdbSyncStream(
-        private val stream: AdbStream
+        private val stream: AdbStream,
+        private val features: Set<String> = emptySet(),
 ) : AutoCloseable {
 
     private val buffer = Buffer()
+    private val isWindowsHost =
+        System.getProperty("os.name")?.startsWith("Windows", ignoreCase = true) == true
 
     @Throws(IOException::class)
     fun send(source: Source, remotePath: String, mode: Int, lastModifiedMs: Long) {
-        val remote = "$remotePath,$mode"
-        writePacket(SEND, remote.toByteArray().size)
-
-        stream.sink.apply {
-            writeString(remote, StandardCharsets.UTF_8)
-            flush()
+        if (supportsFeature(FEATURE_SENDRECV_V2)) {
+            sendV2(source, remotePath, mode, lastModifiedMs)
+        } else {
+            sendV1(source, remotePath, mode, lastModifiedMs)
         }
-
-        buffer.clear()
-
-        while (true) {
-            val read = source.read(buffer, 64_000)
-            if (read == -1L) break
-            writePacket(DATA, read.toInt())
-            val sent = stream.sink.writeAll(buffer)
-            check(read == sent)
-        }
-
-        writePacket(DONE, (lastModifiedMs / 1000).toInt())
-
-        stream.sink.flush()
-
-        val packet = readPacket()
-        if (packet.id != OKAY) throw IOException("Unexpected sync packet id: ${packet.id}")
     }
 
     @Throws(IOException::class)
     fun recv(sink: Sink, remotePath: String) {
-        writePacket(RECV, remotePath.toByteArray().size)
+        if (supportsFeature(FEATURE_SENDRECV_V2)) {
+            recvV2(sink, remotePath)
+        } else {
+            recvV1(sink, remotePath)
+        }
+    }
+
+    @Throws(IOException::class)
+    fun statV2(path: String): AdbSyncStatV2 {
+        requireFeature(FEATURE_STAT_V2, "statV2")
+        return readStatV2(path, STAT_V2, "statV2")
+    }
+
+    @Throws(IOException::class)
+    fun lstatV2(path: String): AdbSyncStatV2 {
+        requireFeature(FEATURE_STAT_V2, "lstatV2")
+        return readStatV2(path, LSTAT_V2, "lstatV2")
+    }
+
+    @Throws(IOException::class)
+    fun lstat(path: String): AdbSyncStat {
+        return if (supportsFeature(FEATURE_STAT_V2)) {
+            val stat = readStatV2(path, LSTAT_V2, "lstat")
+            AdbSyncStat(mode = stat.mode, size = stat.size, mtimeSec = stat.mtimeSec)
+        } else {
+            readLstatV1(path)
+        }
+    }
+
+    @Throws(IOException::class)
+    fun listV2(path: String): List<AdbSyncDirEntryV2> {
+        requireFeature(FEATURE_LS_V2, "listV2")
+        return readListV2(path)
+    }
+
+    @Throws(IOException::class)
+    fun list(path: String): List<AdbSyncDirEntry> {
+        return if (supportsFeature(FEATURE_LS_V2)) {
+            readListV2(path).map {
+                AdbSyncDirEntry(
+                    name = it.name,
+                    mode = it.mode,
+                    size = it.size,
+                    mtimeSec = it.mtimeSec,
+                    errorCode = it.errorCode.takeIf { code -> code != 0 },
+                )
+            }
+        } else {
+            readListV1(path)
+        }
+    }
+
+    @Throws(IOException::class)
+    private fun sendV1(source: Source, remotePath: String, mode: Int, lastModifiedMs: Long) {
+        val remote = "$remotePath,$mode".toByteArray(StandardCharsets.UTF_8)
+        enforcePathLength(remote.size, SEND)
+        writeRequest(SEND, remote)
+        writeSourcePayload(source, lastModifiedMs)
+        readSendStatus()
+    }
+
+    @Throws(IOException::class)
+    private fun sendV2(source: Source, remotePath: String, mode: Int, lastModifiedMs: Long) {
+        val path = remotePath.toByteArray(StandardCharsets.UTF_8)
+        enforcePathLength(path.size, SEND_V2)
         stream.sink.apply {
-            writeString(remotePath, StandardCharsets.UTF_8)
+            writeString(SEND_V2, StandardCharsets.UTF_8)
+            writeIntLe(path.size)
+            write(path)
+            writeString(SEND_V2, StandardCharsets.UTF_8)
+            writeIntLe(mode)
+            writeIntLe(0)
             flush()
         }
+        writeSourcePayload(source, lastModifiedMs)
+        readSendStatus()
+    }
 
+    @Throws(IOException::class)
+    private fun writeSourcePayload(source: Source, lastModifiedMs: Long) {
         buffer.clear()
 
         while (true) {
-            val packet = readPacket()
-            if (packet.id == DONE) break
-            if (packet.id == FAIL) {
-                val message = stream.source.readString(packet.arg.toLong(), StandardCharsets.UTF_8)
-                throw IOException("Sync failed: $message")
+            val read = source.read(buffer, SYNC_DATA_MAX.toLong())
+            if (read == -1L) break
+            stream.sink.apply {
+                writeFrameHeader(DATA, read.toInt())
+                val sent = writeAll(this@AdbSyncStream.buffer)
+                check(read == sent)
+                flush()
             }
-            if (packet.id != DATA) throw IOException("Unexpected sync packet id: ${packet.id}")
-            val chunkSize = packet.arg
-            stream.source.readFully(buffer, chunkSize.toLong())
-            buffer.readAll(sink)
+        }
+        stream.sink.apply {
+            writeFrameHeader(DONE, (lastModifiedMs / 1000).toInt())
+            flush()
+        }
+    }
+
+    @Throws(IOException::class)
+    private fun readSendStatus() {
+        val packet = readPacket()
+        when (packet.id) {
+            OKAY -> return
+            FAIL -> throw readFailException(packet.arg)
+            else -> throw IOException("Unexpected sync packet id: ${packet.id}")
+        }
+    }
+
+    @Throws(IOException::class)
+    private fun recvV1(sink: Sink, remotePath: String) {
+        val path = remotePath.toByteArray(StandardCharsets.UTF_8)
+        enforcePathLength(path.size, RECV)
+        writeRequest(RECV, path)
+        readRecvPayload(sink)
+    }
+
+    @Throws(IOException::class)
+    private fun recvV2(sink: Sink, remotePath: String) {
+        val path = remotePath.toByteArray(StandardCharsets.UTF_8)
+        enforcePathLength(path.size, RECV_V2)
+        stream.sink.apply {
+            writeString(RECV_V2, StandardCharsets.UTF_8)
+            writeIntLe(path.size)
+            write(path)
+            writeString(RECV_V2, StandardCharsets.UTF_8)
+            writeIntLe(0)
+            flush()
+        }
+        readRecvPayload(sink)
+    }
+
+    @Throws(IOException::class)
+    private fun readRecvPayload(sink: Sink) {
+        buffer.clear()
+        while (true) {
+            val packet = readPacket()
+            when (packet.id) {
+                DATA -> {
+                    val chunkSize = packet.arg
+                    if (chunkSize < 0 || chunkSize > SYNC_DATA_MAX) {
+                        throw IOException("Sync DATA chunk too large: $chunkSize > $SYNC_DATA_MAX")
+                    }
+                    stream.source.readFully(buffer, chunkSize.toLong())
+                    buffer.readAll(sink)
+                }
+
+                DONE -> break
+                FAIL -> throw readFailException(packet.arg)
+                else -> throw IOException("Unexpected sync packet id: ${packet.id}")
+            }
         }
 
         sink.flush()
     }
 
-    private fun writePacket(id: String, arg: Int) {
+    @Throws(IOException::class)
+    private fun readStatV2(path: String, requestId: String, apiName: String): AdbSyncStatV2 {
+        val pathBytes = path.toByteArray(StandardCharsets.UTF_8)
+        enforcePathLength(pathBytes.size, requestId)
+        writeRequest(requestId, pathBytes)
+
+        val responseId = readSyncId()
+        if (responseId != STAT_V2 && responseId != LSTAT_V2) {
+            throw IOException("Unexpected sync stat id: $responseId")
+        }
+
+        val stat = AdbSyncStatV2(
+            errorCode = stream.source.readIntLe(),
+            dev = stream.source.readLongLe(),
+            ino = stream.source.readLongLe(),
+            mode = stream.source.readIntLe(),
+            nlink = stream.source.readIntLe(),
+            uid = stream.source.readIntLe(),
+            gid = stream.source.readIntLe(),
+            size = stream.source.readLongLe(),
+            atimeSec = stream.source.readLongLe(),
+            mtimeSec = stream.source.readLongLe(),
+            ctimeSec = stream.source.readLongLe(),
+        )
+
+        if (stat.errorCode != 0) {
+            throw IOException("$apiName failed with error code: ${stat.errorCode}")
+        }
+        return stat
+    }
+
+    @Throws(IOException::class)
+    private fun readLstatV1(path: String): AdbSyncStat {
+        val pathBytes = path.toByteArray(StandardCharsets.UTF_8)
+        enforcePathLength(pathBytes.size, STAT)
+        writeRequest(STAT, pathBytes)
+
+        val responseId = readSyncId()
+        if (responseId != STAT) {
+            throw IOException("Unexpected sync lstat id: $responseId")
+        }
+        val mode = stream.source.readIntLe()
+        val size = readUInt32AsLong()
+        val mtime = readUInt32AsLong()
+        if (mode == 0 && size == 0L && mtime == 0L) {
+            throw IOException("Sync lstat failed: unknown error")
+        }
+        return AdbSyncStat(mode = mode, size = size, mtimeSec = mtime)
+    }
+
+    @Throws(IOException::class)
+    private fun readListV1(path: String): List<AdbSyncDirEntry> {
+        val pathBytes = path.toByteArray(StandardCharsets.UTF_8)
+        enforcePathLength(pathBytes.size, LIST)
+        writeRequest(LIST, pathBytes)
+
+        val entries = mutableListOf<AdbSyncDirEntry>()
+        while (true) {
+            when (val id = readSyncId()) {
+                DENT -> {
+                    val mode = stream.source.readIntLe()
+                    val size = readUInt32AsLong()
+                    val mtime = readUInt32AsLong()
+                    val nameLength = stream.source.readIntLe()
+                    val name = readSyncName(nameLength)
+                    validateEntryName(name)
+                    entries += AdbSyncDirEntry(name = name, mode = mode, size = size, mtimeSec = mtime, errorCode = null)
+                }
+
+                DONE -> {
+                    stream.source.skip(LIST_V1_DONE_TAIL_BYTES)
+                    return entries
+                }
+
+                FAIL -> throw readFailException()
+                else -> throw IOException("Unexpected sync list id: $id")
+            }
+        }
+    }
+
+    @Throws(IOException::class)
+    private fun readListV2(path: String): List<AdbSyncDirEntryV2> {
+        val pathBytes = path.toByteArray(StandardCharsets.UTF_8)
+        enforcePathLength(pathBytes.size, LIST_V2)
+        writeRequest(LIST_V2, pathBytes)
+
+        val entries = mutableListOf<AdbSyncDirEntryV2>()
+        while (true) {
+            when (val id = readSyncId()) {
+                DENT_V2 -> {
+                    val dent = readDentV2()
+                    entries += AdbSyncDirEntryV2(
+                        name = dent.name,
+                        errorCode = dent.errorCode,
+                        dev = dent.dev,
+                        ino = dent.ino,
+                        mode = dent.mode,
+                        nlink = dent.nlink,
+                        uid = dent.uid,
+                        gid = dent.gid,
+                        size = dent.size,
+                        atimeSec = dent.atimeSec,
+                        mtimeSec = dent.mtimeSec,
+                        ctimeSec = dent.ctimeSec,
+                    )
+                }
+
+                DONE -> {
+                    stream.source.skip(LIST_V2_DONE_TAIL_BYTES)
+                    return entries
+                }
+
+                FAIL -> throw readFailException()
+                else -> throw IOException("Unexpected sync list id: $id")
+            }
+        }
+    }
+
+    @Throws(IOException::class)
+    private fun readDentV2(): DentV2Fields {
+        val errorCode = stream.source.readIntLe()
+        val dev = stream.source.readLongLe()
+        val ino = stream.source.readLongLe()
+        val mode = stream.source.readIntLe()
+        val nlink = stream.source.readIntLe()
+        val uid = stream.source.readIntLe()
+        val gid = stream.source.readIntLe()
+        val size = stream.source.readLongLe()
+        val atimeSec = stream.source.readLongLe()
+        val mtimeSec = stream.source.readLongLe()
+        val ctimeSec = stream.source.readLongLe()
+        val nameLength = stream.source.readIntLe()
+        val name = readSyncName(nameLength)
+        validateEntryName(name)
+        return DentV2Fields(
+            errorCode = errorCode,
+            dev = dev,
+            ino = ino,
+            mode = mode,
+            nlink = nlink,
+            uid = uid,
+            gid = gid,
+            size = size,
+            atimeSec = atimeSec,
+            mtimeSec = mtimeSec,
+            ctimeSec = ctimeSec,
+            name = name,
+        )
+    }
+
+    private fun writeRequest(id: String, payload: ByteArray) {
         stream.sink.apply {
-            writeString(id, StandardCharsets.UTF_8)
-            writeIntLe(arg)
+            writeFrameHeader(id, payload.size)
+            write(payload)
             flush()
         }
     }
 
+    private fun writePacket(id: String, arg: Int) {
+        stream.sink.apply {
+            writeFrameHeader(id, arg)
+            flush()
+        }
+    }
+
+    private fun BufferedSink.writeFrameHeader(id: String, arg: Int) {
+        writeString(id, StandardCharsets.UTF_8)
+        writeIntLe(arg)
+    }
+
     private fun readPacket(): Packet {
-        val id = stream.source.readString(4, StandardCharsets.UTF_8)
+        val id = readSyncId()
         val arg = stream.source.readIntLe()
         return Packet(id, arg)
     }
+
+    @Throws(IOException::class)
+    private fun readSyncName(length: Int): String {
+        if (length < 0 || length > SYNC_NAME_MAX) {
+            throw IOException("Invalid sync name length: $length")
+        }
+        return stream.source.readString(length.toLong(), StandardCharsets.UTF_8)
+    }
+
+    private fun validateEntryName(name: String) {
+        if (name.contains('/')) {
+            throw IOException("Invalid sync entry name: $name")
+        }
+        if (isWindowsHost && name.contains('\\')) {
+            throw IOException("Invalid sync entry name: $name")
+        }
+    }
+
+    private fun supportsFeature(feature: String): Boolean = features.contains(feature)
+
+    private fun requireFeature(feature: String, apiName: String) {
+        if (!supportsFeature(feature)) {
+            throw UnsupportedOperationException("$apiName requires peer feature '$feature'")
+        }
+    }
+
+    private fun enforcePathLength(length: Int, requestId: String) {
+        require(length in 0..SYNC_PATH_MAX) {
+            "Sync path too long for $requestId: $length > $SYNC_PATH_MAX"
+        }
+    }
+
+    private fun readFailException(length: Int? = null): IOException {
+        val messageLength = length ?: stream.source.readIntLe()
+        if (messageLength < 0) {
+            return IOException("Sync failed with invalid message length: $messageLength")
+        }
+        val message = stream.source.readString(messageLength.toLong(), StandardCharsets.UTF_8)
+        return IOException("Sync failed: $message")
+    }
+
+    private fun readSyncId(): String = stream.source.readString(4, StandardCharsets.UTF_8)
+
+    private fun readUInt32AsLong(): Long = stream.source.readIntLe().toLong() and 0xFFFF_FFFFL
 
     override fun close() {
         writePacket(QUIT, 0)

--- a/dadb/src/main/kotlin/dadb/AdbSyncModels.kt
+++ b/dadb/src/main/kotlin/dadb/AdbSyncModels.kt
@@ -1,0 +1,56 @@
+package dadb
+
+/**
+ * Compat stat result aligned with AOSP v1 fields.
+ */
+class AdbSyncStat(
+    val mode: Int,
+    val size: Long,
+    val mtimeSec: Long,
+)
+
+/**
+ * Full stat_v2/lstat_v2 result aligned with AOSP sync_stat_v2.
+ */
+class AdbSyncStatV2(
+    val errorCode: Int,
+    val dev: Long,
+    val ino: Long,
+    val mode: Int,
+    val nlink: Int,
+    val uid: Int,
+    val gid: Int,
+    val size: Long,
+    val atimeSec: Long,
+    val mtimeSec: Long,
+    val ctimeSec: Long,
+)
+
+/**
+ * Compat list entry aligned with AOSP v1 dent fields, plus optional v2 error code.
+ */
+class AdbSyncDirEntry(
+    val name: String,
+    val mode: Int,
+    val size: Long,
+    val mtimeSec: Long,
+    val errorCode: Int?,
+)
+
+/**
+ * Full list_v2 entry aligned with AOSP sync_dent_v2.
+ */
+class AdbSyncDirEntryV2(
+    val name: String,
+    val errorCode: Int,
+    val dev: Long,
+    val ino: Long,
+    val mode: Int,
+    val nlink: Int,
+    val uid: Int,
+    val gid: Int,
+    val size: Long,
+    val atimeSec: Long,
+    val mtimeSec: Long,
+    val ctimeSec: Long,
+)

--- a/dadb/src/main/kotlin/dadb/AdbTransport.kt
+++ b/dadb/src/main/kotlin/dadb/AdbTransport.kt
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2021 mobile.dev inc.
+ * Additional transport support by github.com/XRSec/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package dadb
+
+import okio.Sink
+import okio.Source
+import java.io.IOException
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * A low-level transport carrying raw ADB packets.
+ *
+ * Socket is the default implementation, but callers can provide transports backed by
+ * platform-specific APIs, tunnels, in-process bridges, or any other bidirectional channel.
+ */
+interface AdbTransport : AutoCloseable {
+
+    val source: Source
+
+    val sink: Sink
+
+    val connectMaxData: Int
+        get() = Constants.CONNECT_MAXDATA
+
+    val isClosed: Boolean
+
+    val description: String
+        get() = javaClass.name
+}
+
+fun interface AdbTransportFactory {
+
+    val description: String
+        get() = javaClass.name
+
+    @Throws(IOException::class)
+    fun connect(): AdbTransport
+}
+
+/**
+ * A transport backed by an existing okio [Source] and [Sink].
+ */
+class SourceSinkAdbTransport(
+    override val source: Source,
+    override val sink: Sink,
+    override val description: String,
+    override val connectMaxData: Int = Constants.CONNECT_MAXDATA,
+    private val closeable: AutoCloseable? = null,
+) : AdbTransport {
+    private val closed = AtomicBoolean(false)
+
+    override val isClosed: Boolean
+        get() = closed.get()
+
+    override fun close() {
+        if (!closed.compareAndSet(false, true)) {
+            return
+        }
+        closeable?.close()
+    }
+}

--- a/dadb/src/main/kotlin/dadb/AdbTransport.kt
+++ b/dadb/src/main/kotlin/dadb/AdbTransport.kt
@@ -44,6 +44,17 @@ interface AdbTransport : AutoCloseable {
         get() = javaClass.name
 }
 
+/**
+ * A transport that can upgrade the current raw socket/channel to TLS in-place after `A_STLS`.
+ *
+ * Wireless Debugging on modern Android starts as plain ADB, negotiates `A_STLS`, then upgrades
+ * the same underlying connection to TLS before continuing with normal ADB auth/CNXN messages.
+ */
+interface TlsUpgradableAdbTransport : AdbTransport {
+    @Throws(IOException::class)
+    fun upgradeToTls(version: Int = Constants.STLS_VERSION)
+}
+
 fun interface AdbTransportFactory {
 
     val description: String
@@ -72,6 +83,11 @@ class SourceSinkAdbTransport(
         if (!closed.compareAndSet(false, true)) {
             return
         }
-        closeable?.close()
+        if (closeable != null) {
+            closeable.close()
+            return
+        }
+        sink.close()
+        source.close()
     }
 }

--- a/dadb/src/main/kotlin/dadb/AdbWriter.kt
+++ b/dadb/src/main/kotlin/dadb/AdbWriter.kt
@@ -25,10 +25,10 @@ internal class AdbWriter(sink: Sink) : AutoCloseable {
 
     private val bufferedSink = sink.buffer()
 
-    fun writeConnect() = write(
+    fun writeConnect(maxData: Int = Constants.CONNECT_MAXDATA) = write(
             Constants.CMD_CNXN,
             Constants.CONNECT_VERSION,
-            Constants.CONNECT_MAXDATA,
+            maxData,
             Constants.CONNECT_PAYLOAD,
             0,
             Constants.CONNECT_PAYLOAD.size

--- a/dadb/src/main/kotlin/dadb/AdbWriter.kt
+++ b/dadb/src/main/kotlin/dadb/AdbWriter.kt
@@ -28,13 +28,13 @@ internal class AdbWriter(sink: Sink) : AutoCloseable {
     @Volatile
     private var protocolVersion: Int = Constants.A_VERSION_MIN
 
-    fun writeConnect(maxData: Int = Constants.CONNECT_MAXDATA) = write(
+    fun writeConnect(maxData: Int = Constants.CONNECT_MAXDATA, connectPayload: ByteArray = Constants.CONNECT_PAYLOAD) = write(
             Constants.CMD_CNXN,
             Constants.CONNECT_VERSION,
             maxData,
-            Constants.CONNECT_PAYLOAD,
+            connectPayload,
             0,
-            Constants.CONNECT_PAYLOAD.size
+            connectPayload.size
     )
 
     fun writeAuth(authType: Int, authPayload: ByteArray) = write(

--- a/dadb/src/main/kotlin/dadb/AdbWriter.kt
+++ b/dadb/src/main/kotlin/dadb/AdbWriter.kt
@@ -43,6 +43,15 @@ internal class AdbWriter(sink: Sink) : AutoCloseable {
             authPayload.size
     )
 
+    fun writeStls(version: Int = Constants.STLS_VERSION) = write(
+            Constants.CMD_STLS,
+            version,
+            0,
+            null,
+            0,
+            0
+    )
+
     fun writeOpen(localId: Int, destination: String) {
         val destinationBytes = destination.toByteArray()
         val buffer = ByteBuffer.allocate(destinationBytes.size + 1)

--- a/dadb/src/main/kotlin/dadb/AdbWriter.kt
+++ b/dadb/src/main/kotlin/dadb/AdbWriter.kt
@@ -20,10 +20,13 @@ package dadb
 import okio.Sink
 import okio.buffer
 import java.nio.ByteBuffer
+import java.nio.ByteOrder
 
 internal class AdbWriter(sink: Sink) : AutoCloseable {
 
     private val bufferedSink = sink.buffer()
+    @Volatile
+    private var protocolVersion: Int = Constants.A_VERSION_MIN
 
     fun writeConnect(maxData: Int = Constants.CONNECT_MAXDATA) = write(
             Constants.CMD_CNXN,
@@ -52,13 +55,13 @@ internal class AdbWriter(sink: Sink) : AutoCloseable {
             0
     )
 
-    fun writeOpen(localId: Int, destination: String) {
+    fun writeOpen(localId: Int, destination: String, arg1: Int = 0) {
         val destinationBytes = destination.toByteArray()
         val buffer = ByteBuffer.allocate(destinationBytes.size + 1)
         buffer.put(destinationBytes)
         buffer.put(0)
         val payload = buffer.array()
-        write(Constants.CMD_OPEN, localId, 0, payload, 0, payload.size)
+        write(Constants.CMD_OPEN, localId, arg1, payload, 0, payload.size)
     }
 
     fun writeWrite(localId: Int, remoteId: Int, payload: ByteArray, offset: Int, length: Int) {
@@ -69,8 +72,18 @@ internal class AdbWriter(sink: Sink) : AutoCloseable {
         write(Constants.CMD_CLSE, localId, remoteId, null, 0, 0)
     }
 
-    fun writeOkay(localId: Int, remoteId: Int) {
-        write(Constants.CMD_OKAY, localId, remoteId, null, 0, 0)
+    fun writeOkay(localId: Int, remoteId: Int, ackBytes: Int? = null) {
+        val payload = ackBytes?.let {
+            ByteBuffer.allocate(Int.SIZE_BYTES)
+                .order(ByteOrder.LITTLE_ENDIAN)
+                .putInt(it)
+                .array()
+        }
+        write(Constants.CMD_OKAY, localId, remoteId, payload, 0, payload?.size ?: 0)
+    }
+
+    fun updateProtocolVersion(peerVersion: Int) {
+        protocolVersion = minOf(peerVersion, Constants.CONNECT_VERSION)
     }
 
     fun write(
@@ -92,7 +105,12 @@ internal class AdbWriter(sink: Sink) : AutoCloseable {
                     writeIntLe(0)
                 } else {
                     writeIntLe(length)
-                    writeIntLe(payloadChecksum(payload))
+                    val checksum = if (protocolVersion >= Constants.A_VERSION_SKIP_CHECKSUM) {
+                        0
+                    } else {
+                        payloadChecksum(payload, offset, length)
+                    }
+                    writeIntLe(checksum)
                 }
                 writeIntLe(command xor -0x1)
                 if (payload != null) {
@@ -109,10 +127,13 @@ internal class AdbWriter(sink: Sink) : AutoCloseable {
 
     companion object {
 
-        private fun payloadChecksum(payload: ByteArray): Int {
+        private fun payloadChecksum(payload: ByteArray, offset: Int, length: Int): Int {
+            require(offset >= 0 && length >= 0 && offset + length <= payload.size) {
+                "payloadChecksum out of bounds: offset=$offset length=$length size=${payload.size}"
+            }
             var checksum = 0
-            for (byte in payload) {
-                checksum += byte.toUByte().toInt()
+            for (i in offset until offset + length) {
+                checksum += payload[i].toUByte().toInt()
             }
             return checksum
         }

--- a/dadb/src/main/kotlin/dadb/Constants.kt
+++ b/dadb/src/main/kotlin/dadb/Constants.kt
@@ -17,6 +17,9 @@
 
 package dadb
 
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+
 internal object Constants {
 
     const val AUTH_TYPE_TOKEN = 1
@@ -31,9 +34,49 @@ internal object Constants {
     const val CMD_CLSE = 0x45534c43
     const val CMD_WRTE = 0x45545257
 
-    const val CONNECT_VERSION = 0x01000000
+    const val A_VERSION_MIN = 0x01000000
+    const val A_VERSION_SKIP_CHECKSUM = 0x01000001
+    const val CONNECT_VERSION = A_VERSION_SKIP_CHECKSUM
+    const val MAX_PAYLOAD_V1 = 4 * 1024
     const val CONNECT_MAXDATA = 1024 * 1024
+    const val INITIAL_DELAYED_ACK_BYTES = 32 * 1024 * 1024
     const val STLS_VERSION = 0x01000000
 
-    val CONNECT_PAYLOAD = "host::\u0000".toByteArray()
+    val CONNECT_FEATURES = listOf(
+        "shell_v2",
+        "cmd",
+        "abb_exec",
+        FEATURE_DELAYED_ACK,
+    )
+
+    const val FEATURE_DELAYED_ACK = "delayed_ack"
+
+    val CONNECT_PAYLOAD = "host::features=${CONNECT_FEATURES.joinToString(",")}".toByteArray().also {
+        require(it.size <= MAX_PAYLOAD_V1) {
+            "ADB connect banner is too long: ${it.size} > $MAX_PAYLOAD_V1"
+        }
+    }
+
+    fun decodeOkayAckBytes(message: AdbMessage, delayedAckEnabled: Boolean): Int {
+        require(message.command == CMD_OKAY) { "Expected OKAY message, got ${message.command}" }
+        return when (message.payloadLength) {
+            0 -> {
+                if (delayedAckEnabled) {
+                    throw java.io.IOException("Delayed ACK stream missing OKAY payload for localId: ${message.arg1.toString(16)}")
+                }
+                0
+            }
+
+            Int.SIZE_BYTES -> {
+                if (!delayedAckEnabled) {
+                    throw java.io.IOException("Unexpected OKAY payload for non-delayed-ack stream: ${message.payloadLength}")
+                }
+                ByteBuffer.wrap(message.payload, 0, Int.SIZE_BYTES)
+                    .order(ByteOrder.LITTLE_ENDIAN)
+                    .int
+            }
+
+            else -> throw java.io.IOException("Invalid OKAY payload size: ${message.payloadLength}")
+        }
+    }
 }

--- a/dadb/src/main/kotlin/dadb/Constants.kt
+++ b/dadb/src/main/kotlin/dadb/Constants.kt
@@ -25,6 +25,7 @@ internal object Constants {
 
     const val CMD_AUTH = 0x48545541
     const val CMD_CNXN = 0x4e584e43
+    const val CMD_STLS = 0x534c5453
     const val CMD_OPEN = 0x4e45504f
     const val CMD_OKAY = 0x59414b4f
     const val CMD_CLSE = 0x45534c43
@@ -32,6 +33,7 @@ internal object Constants {
 
     const val CONNECT_VERSION = 0x01000000
     const val CONNECT_MAXDATA = 1024 * 1024
+    const val STLS_VERSION = 0x01000000
 
     val CONNECT_PAYLOAD = "host::\u0000".toByteArray()
 }

--- a/dadb/src/main/kotlin/dadb/Dadb.kt
+++ b/dadb/src/main/kotlin/dadb/Dadb.kt
@@ -31,7 +31,11 @@ interface Dadb : AutoCloseable {
 
     fun supportsFeature(feature: String): Boolean
 
+    fun supportsDelayedAck(): Boolean = supportsFeature(Constants.FEATURE_DELAYED_ACK)
+
     fun isTlsConnection(): Boolean
+
+    fun reconnect(withDelayedAck: Boolean)
 
     @Throws(IOException::class)
     fun shell(command: String): AdbShellResponse {

--- a/dadb/src/main/kotlin/dadb/Dadb.kt
+++ b/dadb/src/main/kotlin/dadb/Dadb.kt
@@ -21,6 +21,7 @@ import dadb.adbserver.AdbServer
 import dadb.forwarding.TcpForwarder
 import java.io.File
 import java.nio.file.Files
+import java.nio.file.FileSystems
 import okio.*
 
 interface Dadb : AutoCloseable {
@@ -34,15 +35,45 @@ interface Dadb : AutoCloseable {
 
     @Throws(IOException::class)
     fun shell(command: String): AdbShellResponse {
-        openShell(command).use { stream ->
-            return stream.readAll()
+        return if (supportsFeature(SHELL_V2_FEATURE)) {
+            openShell(command).use { stream ->
+                stream.readAll()
+            }
+        } else {
+            open(buildShellService(command, useShellProtocol = false)).use { stream ->
+                AdbShellResponse(
+                    output = stream.source.readString(Charsets.UTF_8),
+                    errorOutput = "",
+                    exitCode = 0,
+                )
+            }
         }
     }
 
     @Throws(IOException::class)
     fun openShell(command: String = ""): AdbShellStream {
-        val stream = open("shell,v2,raw:$command")
+        requireShellV2("openShell")
+        val stream = open(buildShellService(command, useShellProtocol = true))
         return AdbShellStream(stream)
+    }
+
+    private fun requireShellV2(apiName: String) {
+        check(supportsFeature(SHELL_V2_FEATURE)) {
+            "$apiName requires peer feature '$SHELL_V2_FEATURE'; use shell(command) for legacy shell fallback."
+        }
+    }
+
+    private fun buildShellService(
+        command: String,
+        useShellProtocol: Boolean,
+    ): String {
+        val args = mutableListOf<String>()
+        if (useShellProtocol) {
+            args += SHELL_ARG_V2
+            args += SHELL_TYPE_RAW
+        }
+        val prefix = if (args.isEmpty()) SHELL_SERVICE_BASE else "$SHELL_SERVICE_BASE,${args.joinToString(",")}"
+        return "$prefix:$command"
     }
 
     @Throws(IOException::class)
@@ -72,7 +103,8 @@ interface Dadb : AutoCloseable {
     @Throws(IOException::class)
     fun openSync(): AdbSyncStream {
         val stream = open("sync:")
-        return AdbSyncStream(stream)
+        val features = SYNC_FEATURES.filter(::supportsFeature).toSet()
+        return AdbSyncStream(stream, features)
     }
 
     @Throws(IOException::class)
@@ -97,24 +129,71 @@ interface Dadb : AutoCloseable {
             }
         } else {
             val tempFile = kotlin.io.path.createTempFile()
-            val fileSink = tempFile.sink().buffer()
-            fileSink.writeAll(source)
-            fileSink.flush()
-            pmInstall(tempFile.toFile(), *options)
+            try {
+                tempFile.sink().buffer().use { fileSink ->
+                    fileSink.writeAll(source)
+                    fileSink.flush()
+                }
+                pmInstall(tempFile.toFile(), *options)
+            } finally {
+                tempFile.toFile().delete()
+            }
         }
     }
 
     private fun pmInstall(file: File, vararg options: String) {
         val fileName = file.name
         val remotePath = "/data/local/tmp/$fileName"
-        push(file, remotePath)
-        shell("pm install ${options.joinToString(" ")} \"$remotePath\"")
+        try {
+            push(file, remotePath)
+            shell("pm install ${options.joinToString(" ")} \"$remotePath\"")
+        } finally {
+            runCatching {
+                shell("rm -f \"$remotePath\"")
+            }
+        }
     }
 
     @Throws(IOException::class)
     fun installMultiple(apks: List<File>, vararg options: String) {
         // http://aospxref.com/android-12.0.0_r3/xref/packages/modules/adb/client/adb_install.cpp#538
-        if (supportsFeature("cmd")) {
+        if (supportsFeature("abb_exec")) {
+            val totalLength = apks.sumOf { it.length() }
+            abbExec("package", "install-create", "-S", totalLength.toString(), *options).use { createStream ->
+                val response = createStream.source.readString(Charsets.UTF_8)
+                if (!response.startsWith("Success")) {
+                    throw IOException("connect error for create: $response")
+                }
+                val pattern = """\[(\w+)]""".toRegex()
+                val sessionId = pattern.find(response)?.groups?.get(1)?.value ?: throw IOException("failed to create session")
+
+                var error: String? = null
+                apks.forEach { apk ->
+                    abbExec("package", "install-write", "-S", apk.length().toString(), sessionId, apk.name, "-", *options).use { writeStream ->
+                        writeStream.sink.writeAll(apk.source())
+                        writeStream.sink.flush()
+
+                        val writeResponse = writeStream.source.readString(Charsets.UTF_8)
+                        if (!writeResponse.startsWith("Success")) {
+                            error = writeResponse
+                            return@forEach
+                        }
+                    }
+                }
+
+                val finalCommand = if (error == null) "install-commit" else "install-abandon"
+                abbExec("package", finalCommand, sessionId, *options).use { commitStream ->
+                    val finalResponse = commitStream.source.readString(Charsets.UTF_8)
+                    if (!finalResponse.startsWith("Success")) {
+                        throw IOException("failed to finalize session: $commitStream")
+                    }
+                }
+
+                if (error != null) {
+                    throw IOException("Install failed: $error")
+                }
+            }
+        } else if (supportsFeature("cmd")) {
             val totalLength = apks.map { it.length() }.reduce { acc, l ->  acc + l }
             execCmd("package", "install-create", "-S", totalLength.toString(), *options).use { createStream ->
                 val response = createStream.source.readString(Charsets.UTF_8)
@@ -240,18 +319,90 @@ interface Dadb : AutoCloseable {
         waitRootOrClose(this, root = false)
     }
 
-    @Throws(InterruptedException::class)
-    fun tcpForward(hostPort: Int, targetPort: Int): AutoCloseable {
-        val forwarder = TcpForwarder(this, hostPort, targetPort)
+    @Throws(IOException::class, InterruptedException::class)
+    fun tcpForward(hostPort: Int, targetPort: Int): PortForwarder {
+        return forward(hostPort, "tcp:$targetPort")
+    }
+
+    @Throws(IOException::class, InterruptedException::class)
+    fun tcpForward(hostPort: Int, remoteDestination: String): PortForwarder {
+        return forward(hostPort, remoteDestination)
+    }
+
+    @Throws(IOException::class, InterruptedException::class)
+    fun forward(hostPort: Int, remoteDestination: String): PortForwarder {
+        val forwarder = TcpForwarder(this, hostPort, remoteDestination)
         forwarder.start()
 
         return forwarder
     }
 
+    @Throws(IOException::class)
+    fun reverseForward(
+        device: String,
+        host: String,
+        noRebind: Boolean = false,
+    ): String? {
+        requireSupportedReverseHostDestination(host)
+        val payload = executeAdbService(buildReverseForwardDestination(device, host, noRebind))
+        return payload.ifBlank { null }
+    }
+
+    @Throws(IOException::class)
+    fun reverseForward(
+        devicePort: Int,
+        hostPort: Int,
+        noRebind: Boolean = false,
+    ): String? {
+        return reverseForward(
+            device = "tcp:$devicePort",
+            host = "tcp:$hostPort",
+            noRebind = noRebind,
+        )
+    }
+
+    @Throws(IOException::class)
+    fun reverseKillForward(device: String) {
+        executeAdbService(buildReverseKillDestination(device))
+    }
+
+    @Throws(IOException::class)
+    fun reverseKillAllForwards() {
+        executeAdbService(buildReverseKillAllDestination())
+    }
+
+    @Throws(IOException::class)
+    fun reverseListForwards(): List<AdbReverseRule> {
+        return parseReverseListOutput(executeAdbService(buildReverseListDestination()))
+    }
+
+    @Throws(IOException::class)
+    fun reverseLocalAbstract(
+        deviceSocketName: String,
+        hostPort: Int,
+        noRebind: Boolean = false,
+    ): String? {
+        require(deviceSocketName.isNotBlank()) { "deviceSocketName must not be blank" }
+        return reverseForward(
+            device = "localabstract:$deviceSocketName",
+            host = "tcp:$hostPort",
+            noRebind = noRebind,
+        )
+    }
+
     companion object {
+        private const val SHELL_V2_FEATURE = "shell_v2"
+        private const val SHELL_SERVICE_BASE = "shell"
+        private const val SHELL_ARG_V2 = "v2"
+        private const val SHELL_TYPE_RAW = "raw"
+        private val SYNC_FEATURES = setOf(FEATURE_STAT_V2, FEATURE_LS_V2, FEATURE_SENDRECV_V2)
 
         private const val MIN_EMULATOR_PORT = 5555
         private const val MAX_EMULATOR_PORT = 5683
+        private const val DEFAULT_MODE = 0b110100100
+        private val isPosixFs: Boolean by lazy {
+            FileSystems.getDefault().supportedFileAttributeViews().contains("posix")
+        }
 
         @JvmStatic
         @JvmOverloads
@@ -328,7 +479,11 @@ interface Dadb : AutoCloseable {
         }
 
         private fun readMode(file: File): Int {
-            return Files.getAttribute(file.toPath(), "unix:mode") as? Int ?: throw RuntimeException("Unable to read file mode")
+            if (!isPosixFs) {
+                return DEFAULT_MODE
+            }
+            val mode = Files.getAttribute(file.toPath(), "unix:mode") as? Int
+            return mode ?: DEFAULT_MODE
         }
     }
 }

--- a/dadb/src/main/kotlin/dadb/Dadb.kt
+++ b/dadb/src/main/kotlin/dadb/Dadb.kt
@@ -257,6 +257,22 @@ interface Dadb : AutoCloseable {
 
         @JvmStatic
         @JvmOverloads
+        fun create(transportFactory: AdbTransportFactory, keyPair: AdbKeyPair? = AdbKeyPair.readDefault()): Dadb = DadbImpl(transportFactory = transportFactory, keyPair = keyPair)
+
+        @JvmStatic
+        @JvmOverloads
+        fun create(description: String, keyPair: AdbKeyPair? = AdbKeyPair.readDefault(), connector: () -> AdbTransport): Dadb {
+            val transportFactory =
+                object : AdbTransportFactory {
+                    override val description = description
+
+                    override fun connect(): AdbTransport = connector()
+                }
+            return DadbImpl(transportFactory = transportFactory, keyPair = keyPair)
+        }
+
+        @JvmStatic
+        @JvmOverloads
         fun discover(host: String = "localhost", keyPair: AdbKeyPair? = AdbKeyPair.readDefault(), connectTimeout: Int = 0, socketTimeout: Int = 0, keepAlive: Boolean = false): Dadb? {
             return list(host, keyPair, connectTimeout, socketTimeout, keepAlive).firstOrNull()
         }
@@ -296,7 +312,7 @@ interface Dadb : AutoCloseable {
 
         private fun restartAdb(dadb: Dadb, destination: String): String {
             dadb.open(destination).use { stream ->
-                return stream.source.readUntil('\n'.toByte()).readString(Charsets.UTF_8)
+                return stream.source.readUntil('\n'.code.toByte()).readString(Charsets.UTF_8)
             }
         }
 

--- a/dadb/src/main/kotlin/dadb/Dadb.kt
+++ b/dadb/src/main/kotlin/dadb/Dadb.kt
@@ -30,6 +30,8 @@ interface Dadb : AutoCloseable {
 
     fun supportsFeature(feature: String): Boolean
 
+    fun isTlsConnection(): Boolean
+
     @Throws(IOException::class)
     fun shell(command: String): AdbShellResponse {
         openShell(command).use { stream ->

--- a/dadb/src/main/kotlin/dadb/Dadb.kt
+++ b/dadb/src/main/kotlin/dadb/Dadb.kt
@@ -31,11 +31,7 @@ interface Dadb : AutoCloseable {
 
     fun supportsFeature(feature: String): Boolean
 
-    fun supportsDelayedAck(): Boolean = supportsFeature(Constants.FEATURE_DELAYED_ACK)
-
     fun isTlsConnection(): Boolean
-
-    fun reconnect(withDelayedAck: Boolean)
 
     @Throws(IOException::class)
     fun shell(command: String): AdbShellResponse {
@@ -400,13 +396,24 @@ interface Dadb : AutoCloseable {
         private const val SHELL_ARG_V2 = "v2"
         private const val SHELL_TYPE_RAW = "raw"
         private val SYNC_FEATURES = setOf(FEATURE_STAT_V2, FEATURE_LS_V2, FEATURE_SENDRECV_V2)
+        private val DEFAULT_CONNECT_FEATURES = Constants.CONNECT_FEATURES.toSet()
 
         private const val MIN_EMULATOR_PORT = 5555
         private const val MAX_EMULATOR_PORT = 5683
         private const val DEFAULT_MODE = 0b110100100
+        const val FEATURE_DELAYED_ACK = "delayed_ack"
         private val isPosixFs: Boolean by lazy {
             FileSystems.getDefault().supportedFileAttributeViews().contains("posix")
         }
+
+        @JvmStatic
+        @JvmOverloads
+        fun connectFeatures(withDelayedAck: Boolean = true): Set<String> =
+            if (withDelayedAck) {
+                DEFAULT_CONNECT_FEATURES
+            } else {
+                DEFAULT_CONNECT_FEATURES - FEATURE_DELAYED_ACK
+            }
 
         @JvmStatic
         @JvmOverloads
@@ -414,7 +421,7 @@ interface Dadb : AutoCloseable {
 
         @JvmStatic
         @JvmOverloads
-        fun create(transportFactory: AdbTransportFactory, keyPair: AdbKeyPair? = AdbKeyPair.readDefault()): Dadb = DadbImpl(transportFactory = transportFactory, keyPair = keyPair)
+        fun create(transportFactory: AdbTransportFactory, keyPair: AdbKeyPair? = AdbKeyPair.readDefault(), features: Set<String> = connectFeatures()): Dadb = DadbImpl(transportFactory = transportFactory, keyPair = keyPair, features = features)
 
         @JvmStatic
         @JvmOverloads

--- a/dadb/src/main/kotlin/dadb/DadbImpl.kt
+++ b/dadb/src/main/kotlin/dadb/DadbImpl.kt
@@ -73,6 +73,10 @@ internal class DadbImpl @Throws(IllegalArgumentException::class) constructor(
         return connection().supportsFeature(feature)
     }
 
+    override fun isTlsConnection(): Boolean {
+        return connection().isTlsConnection()
+    }
+
     override fun close() {
         connection?.first?.close()
     }

--- a/dadb/src/main/kotlin/dadb/DadbImpl.kt
+++ b/dadb/src/main/kotlin/dadb/DadbImpl.kt
@@ -20,6 +20,8 @@ package dadb
 import okio.sink
 import okio.source
 import org.jetbrains.annotations.TestOnly
+import java.io.EOFException
+import java.io.IOException
 import java.net.InetSocketAddress
 import java.net.Socket
 import kotlin.jvm.Throws
@@ -67,7 +69,7 @@ internal class DadbImpl @Throws(IllegalArgumentException::class) constructor(
 
     private var connection: Pair<AdbConnection, AdbTransport>? = null
 
-    override fun open(destination: String) = connection().open(destination)
+    override fun open(destination: String) = openWithRetry(destination)
 
     override fun supportsFeature(feature: String): Boolean {
         return connection().supportsFeature(feature)
@@ -79,12 +81,14 @@ internal class DadbImpl @Throws(IllegalArgumentException::class) constructor(
 
     override fun close() {
         connection?.first?.close()
+        connection = null
     }
     override fun toString() = description
 
     @TestOnly
     fun closeConnection() {
         connection?.second?.close()
+        connection = null
     }
 
     @Synchronized
@@ -101,6 +105,67 @@ internal class DadbImpl @Throws(IllegalArgumentException::class) constructor(
         val transport = transportFactory.connect()
         val adbConnection = AdbConnection.connect(transport, keyPair)
         return adbConnection to transport
+    }
+
+    private fun openWithRetry(
+        destination: String,
+        retryOnStaleConnection: Boolean = true,
+    ): AdbStream {
+        val connection = connectionPair()
+        return try {
+            connection.first.open(destination)
+        } catch (t: Throwable) {
+            if (!retryOnStaleConnection || !isRecoverableOpenFailure(t)) {
+                throw t
+            }
+            discardConnection(connection.first)
+            openWithRetry(destination, retryOnStaleConnection = false)
+        }
+    }
+
+    @Synchronized
+    private fun connectionPair(): Pair<AdbConnection, AdbTransport> {
+        var connection = connection
+        if (connection == null || connection.second.isClosed) {
+            connection = newConnection()
+            this.connection = connection
+        }
+        return connection
+    }
+
+    @Synchronized
+    private fun discardConnection(failedConnection: AdbConnection) {
+        val current = connection
+        if (current?.first === failedConnection) {
+            runCatching { current.first.close() }
+            connection = null
+        } else {
+            runCatching { failedConnection.close() }
+        }
+    }
+
+    private fun isRecoverableOpenFailure(error: Throwable): Boolean {
+        return when (error) {
+            is EOFException -> true
+            is IOException, is IllegalStateException -> {
+                val message = error.message.orEmpty().lowercase()
+                OPEN_FAILURE_MARKERS.any(message::contains) ||
+                    error.cause?.let(::isRecoverableOpenFailure) == true
+            }
+            else -> error.cause?.let(::isRecoverableOpenFailure) == true
+        }
+    }
+
+    private companion object {
+        private val OPEN_FAILURE_MARKERS =
+            listOf(
+                "closed",
+                "broken pipe",
+                "connection reset",
+                "connection abort",
+                "unexpected end",
+                "eof",
+            )
     }
 
     private class SocketAdbTransportFactory(

--- a/dadb/src/main/kotlin/dadb/DadbImpl.kt
+++ b/dadb/src/main/kotlin/dadb/DadbImpl.kt
@@ -31,15 +31,18 @@ internal class DadbImpl @Throws(IllegalArgumentException::class) constructor(
         private val description: String,
         private val transportFactory: AdbTransportFactory,
         private val keyPair: AdbKeyPair? = null,
+        private val features: Set<String> = Constants.CONNECT_FEATURES.toSet(),
 ) : Dadb {
 
     internal constructor(
         transportFactory: AdbTransportFactory,
         keyPair: AdbKeyPair? = null,
+        features: Set<String> = Constants.CONNECT_FEATURES.toSet(),
     ) : this(
         description = transportFactory.description,
         transportFactory = transportFactory,
         keyPair = keyPair,
+        features = features,
     )
 
     internal constructor(
@@ -68,7 +71,6 @@ internal class DadbImpl @Throws(IllegalArgumentException::class) constructor(
     }
 
     private var connection: Pair<AdbConnection, AdbTransport>? = null
-    private var preferredFeatures: Set<String> = Constants.CONNECT_FEATURES.toSet()
 
     override fun open(destination: String) = openWithRetry(destination)
 
@@ -104,25 +106,8 @@ internal class DadbImpl @Throws(IllegalArgumentException::class) constructor(
 
     private fun newConnection(): Pair<AdbConnection, AdbTransport> {
         val transport = transportFactory.connect()
-        val adbConnection = AdbConnection.connect(transport, keyPair, preferredFeatures)
+        val adbConnection = AdbConnection.connect(transport, keyPair, features)
         return adbConnection to transport
-    }
-
-    @Synchronized
-    override fun reconnect(withDelayedAck: Boolean) {
-        val current = connection
-        if (current != null && !current.second.isClosed) {
-            val hasDelayedAck = current.first.supportsFeature(Constants.FEATURE_DELAYED_ACK)
-            if (hasDelayedAck == withDelayedAck) return
-        }
-        connection?.first?.close()
-        connection = null
-        preferredFeatures = if (withDelayedAck) {
-            Constants.CONNECT_FEATURES.toSet()
-        } else {
-            Constants.CONNECT_FEATURES.toSet() - Constants.FEATURE_DELAYED_ACK
-        }
-        connection = newConnection()
     }
 
     private fun openWithRetry(

--- a/dadb/src/main/kotlin/dadb/DadbImpl.kt
+++ b/dadb/src/main/kotlin/dadb/DadbImpl.kt
@@ -17,6 +17,8 @@
 
 package dadb
 
+import okio.sink
+import okio.source
 import org.jetbrains.annotations.TestOnly
 import java.net.InetSocketAddress
 import java.net.Socket
@@ -24,16 +26,32 @@ import kotlin.jvm.Throws
 
 
 internal class DadbImpl @Throws(IllegalArgumentException::class) constructor(
-        private val host: String,
-        private val port: Int,
+        private val description: String,
+        private val transportFactory: AdbTransportFactory,
         private val keyPair: AdbKeyPair? = null,
-        private val connectTimeout: Int = 0,
-        private val socketTimeout: Int = 0,
-        private val keepAlive: Boolean = false,
 ) : Dadb {
 
-    init {
+    internal constructor(
+        transportFactory: AdbTransportFactory,
+        keyPair: AdbKeyPair? = null,
+    ) : this(
+        description = transportFactory.description,
+        transportFactory = transportFactory,
+        keyPair = keyPair,
+    )
 
+    internal constructor(
+        host: String,
+        port: Int,
+        keyPair: AdbKeyPair? = null,
+        connectTimeout: Int = 0,
+        socketTimeout: Int = 0,
+        keepAlive: Boolean = false,
+    ) : this(
+        description = "$host:$port",
+        transportFactory = SocketAdbTransportFactory(host, port, connectTimeout, socketTimeout, keepAlive),
+        keyPair = keyPair,
+    ) {
         if (port < 0) {
             throw IllegalArgumentException("port must be >= 0")
         }
@@ -45,11 +63,9 @@ internal class DadbImpl @Throws(IllegalArgumentException::class) constructor(
         if (socketTimeout < 0) {
             throw IllegalArgumentException("socketTimeout must be >= 0")
         }
-
     }
 
-
-    private var connection: Pair<AdbConnection, Socket>? = null
+    private var connection: Pair<AdbConnection, AdbTransport>? = null
 
     override fun open(destination: String) = connection().open(destination)
 
@@ -60,7 +76,7 @@ internal class DadbImpl @Throws(IllegalArgumentException::class) constructor(
     override fun close() {
         connection?.first?.close()
     }
-    override fun toString() = "$host:$port"
+    override fun toString() = description
 
     @TestOnly
     fun closeConnection() {
@@ -77,15 +93,45 @@ internal class DadbImpl @Throws(IllegalArgumentException::class) constructor(
         return connection.first
     }
 
-    private fun newConnection(): Pair<AdbConnection, Socket> {
-        val socketAddress = InetSocketAddress(host, port)
-        val socket = Socket()
-        socket.soTimeout = socketTimeout
-        socket.connect(socketAddress, connectTimeout)
-        if (keepAlive) {
-            socket.keepAlive = true
-        }
-        val adbConnection = AdbConnection.connect(socket, keyPair)
-        return adbConnection to socket
+    private fun newConnection(): Pair<AdbConnection, AdbTransport> {
+        val transport = transportFactory.connect()
+        val adbConnection = AdbConnection.connect(transport, keyPair)
+        return adbConnection to transport
     }
+
+    private class SocketAdbTransportFactory(
+        private val host: String,
+        private val port: Int,
+        private val connectTimeout: Int,
+        private val socketTimeout: Int,
+        private val keepAlive: Boolean,
+    ) : AdbTransportFactory {
+        override val description: String = "$host:$port"
+
+        override fun connect(): AdbTransport {
+            val socketAddress = InetSocketAddress(host, port)
+            val socket = Socket()
+            socket.soTimeout = socketTimeout
+            socket.connect(socketAddress, connectTimeout)
+            if (keepAlive) {
+                socket.keepAlive = true
+            }
+            return SocketAdbTransport(socket, description)
+        }
+    }
+
+    private class SocketAdbTransport(
+        private val socket: Socket,
+        override val description: String,
+    ) : AdbTransport {
+        override val source = socket.source()
+        override val sink = socket.sink()
+        override val isClosed: Boolean
+            get() = socket.isClosed
+
+        override fun close() {
+            socket.close()
+        }
+    }
+
 }

--- a/dadb/src/main/kotlin/dadb/DadbImpl.kt
+++ b/dadb/src/main/kotlin/dadb/DadbImpl.kt
@@ -68,6 +68,7 @@ internal class DadbImpl @Throws(IllegalArgumentException::class) constructor(
     }
 
     private var connection: Pair<AdbConnection, AdbTransport>? = null
+    private var preferredFeatures: Set<String> = Constants.CONNECT_FEATURES.toSet()
 
     override fun open(destination: String) = openWithRetry(destination)
 
@@ -103,8 +104,25 @@ internal class DadbImpl @Throws(IllegalArgumentException::class) constructor(
 
     private fun newConnection(): Pair<AdbConnection, AdbTransport> {
         val transport = transportFactory.connect()
-        val adbConnection = AdbConnection.connect(transport, keyPair)
+        val adbConnection = AdbConnection.connect(transport, keyPair, preferredFeatures)
         return adbConnection to transport
+    }
+
+    @Synchronized
+    override fun reconnect(withDelayedAck: Boolean) {
+        val current = connection
+        if (current != null && !current.second.isClosed) {
+            val hasDelayedAck = current.first.supportsFeature(Constants.FEATURE_DELAYED_ACK)
+            if (hasDelayedAck == withDelayedAck) return
+        }
+        connection?.first?.close()
+        connection = null
+        preferredFeatures = if (withDelayedAck) {
+            Constants.CONNECT_FEATURES.toSet()
+        } else {
+            Constants.CONNECT_FEATURES.toSet() - Constants.FEATURE_DELAYED_ACK
+        }
+        connection = newConnection()
     }
 
     private fun openWithRetry(

--- a/dadb/src/main/kotlin/dadb/PortForwarder.kt
+++ b/dadb/src/main/kotlin/dadb/PortForwarder.kt
@@ -1,0 +1,5 @@
+package dadb
+
+interface PortForwarder : AutoCloseable {
+    fun isRunning(): Boolean
+}

--- a/dadb/src/main/kotlin/dadb/adbserver/AdbServer.kt
+++ b/dadb/src/main/kotlin/dadb/adbserver/AdbServer.kt
@@ -1,19 +1,19 @@
 package dadb.adbserver
 
-import dadb.AdbConnection
 import dadb.AdbStream
 import dadb.Dadb
 import okio.buffer
 import okio.sink
 import okio.source
-import java.io.*
+import java.io.DataInputStream
+import java.io.DataOutputStream
+import java.io.IOException
+import java.io.OutputStreamWriter
 import java.net.InetSocketAddress
 import java.net.Socket
 import java.nio.charset.StandardCharsets
 
-
 object AdbServer {
-
     /**
      * Experimental API
      *
@@ -48,11 +48,12 @@ object AdbServer {
         adbServerPort: Int = 5037,
         deviceQuery: String = "host:transport-any",
         connectTimeout: Int = 0,
-        socketTimeout: Int = 0
+        socketTimeout: Int = 0,
     ): Dadb {
-        val name = deviceQuery
-            .removePrefix("host:") // Use the device query without the host: prefix
-            .removePrefix("transport:") // If it's a serial-number, just show that
+        val name =
+            deviceQuery
+                .removePrefix("host:") // Use the device query without the host: prefix
+                .removePrefix("transport:") // If it's a serial-number, just show that
         return AdbServerDadb(adbServerHost, adbServerPort, deviceQuery, name, connectTimeout, socketTimeout)
     }
 
@@ -68,11 +69,13 @@ object AdbServer {
         if (!AdbBinary.tryStartServer(adbServerHost, adbServerPort)) {
             return emptyList()
         }
-        val output = Socket(adbServerHost, adbServerPort).use { socket ->
-            send(socket, "host:devices")
-            readString(DataInputStream(socket.getInputStream()))
-        }
-        return output.lines()
+        val output =
+            Socket(adbServerHost, adbServerPort).use { socket ->
+                send(socket, "host:devices")
+                readString(DataInputStream(socket.getInputStream()))
+            }
+        return output
+            .lines()
             .filter { it.isNotBlank() }
             .mapNotNull {
                 val parts = it.split("\t")
@@ -81,8 +84,7 @@ object AdbServer {
                 } else {
                     parts[0]
                 }
-            }
-            .map { createDadb(adbServerHost, adbServerPort, "host:transport:${it}") }
+            }.map { createDadb(adbServerHost, adbServerPort, "host:transport:$it") }
     }
 
     internal fun readString(inputStream: DataInputStream): String {
@@ -91,7 +93,10 @@ object AdbServer {
         return readString(inputStream, length)
     }
 
-    internal fun send(socket: Socket, command: String) {
+    internal fun send(
+        socket: Socket,
+        command: String,
+    ) {
         val inputStream = DataInputStream(socket.getInputStream())
         val outputStream = DataOutputStream(socket.getOutputStream())
 
@@ -104,7 +109,10 @@ object AdbServer {
         }
     }
 
-    private fun writeString(outputStream: DataOutputStream, string: String) {
+    private fun writeString(
+        outputStream: DataOutputStream,
+        string: String,
+    ) {
         OutputStreamWriter(outputStream, StandardCharsets.UTF_8).apply {
             write(String.format("%04x", string.toByteArray().size))
             write(string)
@@ -112,7 +120,10 @@ object AdbServer {
         }
     }
 
-    private fun readString(inputStream: DataInputStream, length: Int): String {
+    private fun readString(
+        inputStream: DataInputStream,
+        length: Int,
+    ): String {
         val responseBuffer = ByteArray(length)
         inputStream.readFully(responseBuffer)
         return String(responseBuffer, StandardCharsets.UTF_8)
@@ -127,17 +138,20 @@ private class AdbServerDadb constructor(
     private val connectTimeout: Int = 0,
     private val socketTimeout: Int = 0,
 ) : Dadb {
-
     private val supportedFeatures: Set<String>
 
     init {
-        supportedFeatures = open("host:features").use {
-            val features = AdbServer.readString(DataInputStream(it.source.inputStream()))
-            features.split(",").toSet()
-        }
+        supportedFeatures =
+            open("host:features").use {
+                val features = AdbServer.readString(DataInputStream(it.source.inputStream()))
+                features.split(",").toSet()
+            }
     }
 
-    override fun open(destination: String): AdbStream {
+    override fun open(
+        destination: String,
+        enableDelayedAck: Boolean,
+    ): AdbStream {
         AdbBinary.ensureServerRunning(host, port)
 
         val socketAddress = InetSocketAddress(host, port)
@@ -148,7 +162,6 @@ private class AdbServerDadb constructor(
         AdbServer.send(socket, deviceQuery)
         AdbServer.send(socket, destination)
         return object : AdbStream {
-
             override val source = socket.source().buffer()
 
             override val sink = socket.sink().buffer()
@@ -157,17 +170,11 @@ private class AdbServerDadb constructor(
         }
     }
 
-    override fun supportsFeature(feature: String): Boolean {
-        return feature in supportedFeatures
-    }
+    override fun supportsFeature(feature: String): Boolean = feature in supportedFeatures
 
-    override fun isTlsConnection(): Boolean {
-        return false
-    }
+    override fun isTlsConnection(): Boolean = false
 
     override fun close() {}
 
-    override fun toString(): String {
-        return name
-    }
+    override fun toString(): String = name
 }

--- a/dadb/src/main/kotlin/dadb/adbserver/AdbServer.kt
+++ b/dadb/src/main/kotlin/dadb/adbserver/AdbServer.kt
@@ -1,7 +1,6 @@
 package dadb.adbserver
 
 import dadb.AdbStream
-import dadb.Constants
 import dadb.Dadb
 import okio.buffer
 import okio.sink
@@ -140,7 +139,6 @@ private class AdbServerDadb constructor(
     private val socketTimeout: Int = 0,
 ) : Dadb {
     private val supportedFeatures: Set<String>
-    private var delayedAckEnabled: Boolean = false
 
     init {
         supportedFeatures =
@@ -171,13 +169,7 @@ private class AdbServerDadb constructor(
 
     override fun supportsFeature(feature: String): Boolean = feature in supportedFeatures
 
-    override fun supportsDelayedAck(): Boolean = delayedAckEnabled && supportsFeature(Constants.FEATURE_DELAYED_ACK)
-
     override fun isTlsConnection(): Boolean = false
-
-    override fun reconnect(withDelayedAck: Boolean) {
-        delayedAckEnabled = withDelayedAck
-    }
 
     override fun close() {}
 

--- a/dadb/src/main/kotlin/dadb/adbserver/AdbServer.kt
+++ b/dadb/src/main/kotlin/dadb/adbserver/AdbServer.kt
@@ -1,6 +1,7 @@
 package dadb.adbserver
 
 import dadb.AdbStream
+import dadb.Constants
 import dadb.Dadb
 import okio.buffer
 import okio.sink
@@ -139,6 +140,7 @@ private class AdbServerDadb constructor(
     private val socketTimeout: Int = 0,
 ) : Dadb {
     private val supportedFeatures: Set<String>
+    private var delayedAckEnabled: Boolean = false
 
     init {
         supportedFeatures =
@@ -148,10 +150,7 @@ private class AdbServerDadb constructor(
             }
     }
 
-    override fun open(
-        destination: String,
-        enableDelayedAck: Boolean,
-    ): AdbStream {
+    override fun open(destination: String): AdbStream {
         AdbBinary.ensureServerRunning(host, port)
 
         val socketAddress = InetSocketAddress(host, port)
@@ -172,7 +171,13 @@ private class AdbServerDadb constructor(
 
     override fun supportsFeature(feature: String): Boolean = feature in supportedFeatures
 
+    override fun supportsDelayedAck(): Boolean = delayedAckEnabled && supportsFeature(Constants.FEATURE_DELAYED_ACK)
+
     override fun isTlsConnection(): Boolean = false
+
+    override fun reconnect(withDelayedAck: Boolean) {
+        delayedAckEnabled = withDelayedAck
+    }
 
     override fun close() {}
 

--- a/dadb/src/main/kotlin/dadb/adbserver/AdbServer.kt
+++ b/dadb/src/main/kotlin/dadb/adbserver/AdbServer.kt
@@ -161,6 +161,10 @@ private class AdbServerDadb constructor(
         return feature in supportedFeatures
     }
 
+    override fun isTlsConnection(): Boolean {
+        return false
+    }
+
     override fun close() {}
 
     override fun toString(): String {

--- a/dadb/src/main/kotlin/dadb/adbserver/AdbServerForward.kt
+++ b/dadb/src/main/kotlin/dadb/adbserver/AdbServerForward.kt
@@ -1,0 +1,110 @@
+package dadb.adbserver
+
+import java.io.DataInputStream
+import java.io.IOException
+import java.net.Socket
+
+data class AdbForwardRule(
+    val serial: String,
+    val local: String,
+    val remote: String,
+)
+
+@Throws(IOException::class)
+@JvmOverloads
+fun AdbServer.listForwards(
+    adbServerHost: String = "localhost",
+    adbServerPort: Int = 5037,
+    serial: String? = null,
+): List<AdbForwardRule> {
+    val output = queryHostService(adbServerHost, adbServerPort, buildHostForwardCommand("list-forward", serial))
+    return parseForwardListOutput(output)
+}
+
+@Throws(IOException::class)
+@JvmOverloads
+fun AdbServer.forward(
+    local: String,
+    remote: String,
+    adbServerHost: String = "localhost",
+    adbServerPort: Int = 5037,
+    serial: String? = null,
+    noRebind: Boolean = false,
+): String? {
+    require(local.isNotBlank()) { "local must not be blank" }
+    require(remote.isNotBlank()) { "remote must not be blank" }
+    val prefix = if (noRebind) "forward:norebind:" else "forward:"
+    val payload =
+        queryHostService(
+            adbServerHost,
+            adbServerPort,
+            buildHostForwardCommand("$prefix$local;$remote", serial),
+        )
+    return payload.ifBlank { null }
+}
+
+@Throws(IOException::class)
+@JvmOverloads
+fun AdbServer.killForward(
+    local: String,
+    adbServerHost: String = "localhost",
+    adbServerPort: Int = 5037,
+    serial: String? = null,
+) {
+    require(local.isNotBlank()) { "local must not be blank" }
+    queryHostService(adbServerHost, adbServerPort, buildHostForwardCommand("killforward:$local", serial))
+}
+
+@Throws(IOException::class)
+@JvmOverloads
+fun AdbServer.killAllForwards(
+    adbServerHost: String = "localhost",
+    adbServerPort: Int = 5037,
+    serial: String? = null,
+) {
+    queryHostService(adbServerHost, adbServerPort, buildHostForwardCommand("killforward-all", serial))
+}
+
+internal fun buildHostForwardCommand(
+    command: String,
+    serial: String? = null,
+): String {
+    require(command.isNotBlank()) { "command must not be blank" }
+    return if (serial.isNullOrBlank()) {
+        "host:$command"
+    } else {
+        "host-serial:$serial:$command"
+    }
+}
+
+internal fun parseForwardListOutput(output: String): List<AdbForwardRule> {
+    return output
+        .lineSequence()
+        .map { it.trim() }
+        .filter { it.isNotBlank() }
+        .mapNotNull { line ->
+            val fields = line.split(Regex("\\s+"))
+            if (fields.size < 3) {
+                null
+            } else {
+                AdbForwardRule(
+                    serial = fields[0],
+                    local = fields[1],
+                    remote = fields[2],
+                )
+            }
+        }
+        .toList()
+}
+
+private fun queryHostService(
+    adbServerHost: String,
+    adbServerPort: Int,
+    command: String,
+): String {
+    AdbBinary.ensureServerRunning(adbServerHost, adbServerPort)
+    return Socket(adbServerHost, adbServerPort).use { socket ->
+        AdbServer.send(socket, command)
+        AdbServer.readString(DataInputStream(socket.getInputStream()))
+    }
+}

--- a/dadb/src/main/kotlin/dadb/forwarding/ForwardingCore.kt
+++ b/dadb/src/main/kotlin/dadb/forwarding/ForwardingCore.kt
@@ -1,0 +1,274 @@
+package dadb.forwarding
+
+import dadb.Dadb
+import dadb.PortForwarder
+import dadb.log
+import okio.BufferedSink
+import okio.Source
+import java.io.IOException
+import java.io.InterruptedIOException
+import java.net.SocketException
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.ThreadPoolExecutor
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
+import kotlin.concurrent.thread
+
+internal interface ForwardingClient : AutoCloseable {
+    val source: Source
+    val sink: BufferedSink
+}
+
+internal interface ForwardingServer : AutoCloseable {
+    fun accept(): ForwardingClient
+}
+
+internal interface ForwardingDuplex : AutoCloseable {
+    val source: Source
+    val sink: BufferedSink
+}
+
+internal object StreamForwarder {
+    fun transfer(source: Source, sink: BufferedSink) {
+        try {
+            while (!Thread.currentThread().isInterrupted) {
+                try {
+                    if (source.read(sink.buffer, 256) >= 0) {
+                        sink.flush()
+                    } else {
+                        return
+                    }
+                } catch (_: IOException) {
+                    return
+                }
+            }
+        } catch (_: InterruptedException) {
+            // Do nothing.
+        } catch (_: InterruptedIOException) {
+            // Do nothing.
+        }
+    }
+}
+
+internal abstract class BaseForwarder(
+    private val dadb: Dadb,
+    private val remoteDestination: String,
+    private val endpointDescription: String,
+    private val forwardingType: String,
+    private val remoteChannelFactory: (String) -> ForwardingDuplex = { destination ->
+        AdbForwardingDuplex(dadb.open(destination))
+    },
+) : PortForwarder {
+
+    @Volatile
+    private var startupFailure: Throwable? = null
+
+    private var serverThread: Thread? = null
+    private var server: ForwardingServer? = null
+    private var clientExecutor: ExecutorService? = null
+    private val stateController = ForwarderStateController(endpointDescription)
+
+    fun start() {
+        stateController.prepareStart()
+        startupFailure = null
+
+        clientExecutor = createClientExecutor()
+        serverThread = thread {
+            try {
+                handleForwarding()
+            } catch (_: SocketException) {
+                // Expected when the server is closed while stopping.
+            } catch (t: Throwable) {
+                if (stateController.isStarting()) {
+                    startupFailure = t
+                }
+                log { "could not start $forwardingType forwarding: ${t.message}" }
+            } finally {
+                stateController.markStopped()
+            }
+        }
+
+        stateController.awaitStarted()
+        startupFailure?.let { throwStartFailure(it) }
+    }
+
+    override fun isRunning(): Boolean = stateController.isStarted()
+
+    private fun handleForwarding() {
+        val serverRef = createServer()
+        server = serverRef
+
+        stateController.markStarted()
+
+        while (!Thread.currentThread().isInterrupted) {
+            val client = serverRef.accept()
+            clientExecutor?.execute {
+                try {
+                    handleClient(client)
+                } catch (t: Throwable) {
+                    log { "forwarder client failed for $endpointDescription -> $remoteDestination: ${t.message}" }
+                    runCatching { client.close() }
+                }
+            }
+        }
+    }
+
+    private fun handleClient(client: ForwardingClient) {
+        val remoteChannel = remoteChannelFactory(remoteDestination)
+
+        val readerThread = thread {
+            StreamForwarder.transfer(client.source, remoteChannel.sink)
+        }
+
+        try {
+            StreamForwarder.transfer(remoteChannel.source, client.sink)
+        } finally {
+            runCatching { remoteChannel.close() }
+            runCatching { client.close() }
+            readerThread.interrupt()
+        }
+    }
+
+    protected abstract fun createServer(): ForwardingServer
+
+    override fun close() {
+        if (!stateController.shouldStop()) {
+            return
+        }
+
+        stateController.awaitStartedOrStopped()
+        if (!stateController.shouldStop()) {
+            return
+        }
+
+        stateController.markStopping()
+
+        server?.close()
+        server = null
+        serverThread?.interrupt()
+        serverThread = null
+        clientExecutor?.shutdownNow()
+        clientExecutor?.awaitTermination(5, TimeUnit.SECONDS)
+        clientExecutor = null
+
+        stateController.awaitStopped()
+    }
+
+    private fun createClientExecutor(): ExecutorService {
+        return ThreadPoolExecutor(
+            1,
+            MAX_CLIENT_THREADS,
+            60,
+            TimeUnit.SECONDS,
+            LinkedBlockingQueue(MAX_CLIENT_QUEUE_SIZE),
+            ThreadPoolExecutor.CallerRunsPolicy(),
+        )
+    }
+
+    private fun throwStartFailure(failure: Throwable): Nothing {
+        when (failure) {
+            is IOException -> throw failure
+            is RuntimeException -> throw failure
+            is Error -> throw failure
+            else -> throw IOException("Failed to start $forwardingType forwarding at $endpointDescription", failure)
+        }
+    }
+
+    private companion object {
+        const val MAX_CLIENT_THREADS = 32
+        const val MAX_CLIENT_QUEUE_SIZE = 256
+    }
+}
+
+private class AdbForwardingDuplex(
+    private val stream: dadb.AdbStream,
+) : ForwardingDuplex {
+    override val source: Source = stream.source
+    override val sink: BufferedSink = stream.sink
+
+    override fun close() {
+        stream.close()
+    }
+}
+
+private class ForwarderStateController(
+    private val endpointDescription: String,
+) {
+    @Volatile
+    private var state: State = State.STOPPED
+    private val lock = Any()
+    private var startedSignal = CountDownLatch(0)
+    private var stoppedSignal = CountDownLatch(0)
+
+    fun prepareStart() {
+        synchronized(lock) {
+            check(state == State.STOPPED) { "Forwarder is already started at $endpointDescription" }
+            startedSignal = CountDownLatch(1)
+            stoppedSignal = CountDownLatch(1)
+            state = State.STARTING
+        }
+    }
+
+    fun shouldStop(): Boolean = synchronized(lock) {
+        state != State.STOPPED && state != State.STOPPING
+    }
+
+    fun isStarting(): Boolean = state == State.STARTING
+
+    fun isStarted(): Boolean = state == State.STARTED
+
+    fun markStarted() {
+        synchronized(lock) {
+            state = State.STARTED
+            startedSignal.countDown()
+        }
+    }
+
+    fun markStopping() {
+        synchronized(lock) {
+            if (state != State.STOPPED) {
+                state = State.STOPPING
+            }
+        }
+    }
+
+    fun markStopped() {
+        synchronized(lock) {
+            if (state == State.STARTING) {
+                startedSignal.countDown()
+            }
+            state = State.STOPPED
+            stoppedSignal.countDown()
+        }
+    }
+
+    fun awaitStarted() {
+        awaitStateTransition(startedSignal, "start")
+    }
+
+    fun awaitStartedOrStopped() {
+        if (state == State.STOPPED) {
+            return
+        }
+        awaitStarted()
+    }
+
+    fun awaitStopped() {
+        awaitStateTransition(stoppedSignal, "stop")
+    }
+
+    private fun awaitStateTransition(signal: CountDownLatch, action: String) {
+        if (!signal.await(5, TimeUnit.SECONDS)) {
+            throw TimeoutException("Timed out waiting for forwarder to $action")
+        }
+    }
+
+    private enum class State {
+        STARTING,
+        STARTED,
+        STOPPING,
+        STOPPED,
+    }
+}

--- a/dadb/src/main/kotlin/dadb/forwarding/ForwardingCore.kt
+++ b/dadb/src/main/kotlin/dadb/forwarding/ForwardingCore.kt
@@ -158,13 +158,18 @@ internal abstract class BaseForwarder(
 
     private fun createClientExecutor(): ExecutorService {
         return ThreadPoolExecutor(
-            1,
+            MAX_CLIENT_THREADS,
             MAX_CLIENT_THREADS,
             60,
             TimeUnit.SECONDS,
             LinkedBlockingQueue(MAX_CLIENT_QUEUE_SIZE),
             ThreadPoolExecutor.CallerRunsPolicy(),
-        )
+        ).apply {
+            // Multi-socket protocols like scrcpy expect all channels to be connected promptly.
+            // If accepted clients are queued behind a single active worker, the device only sees
+            // the first socket and waits forever for the remaining ones.
+            allowCoreThreadTimeOut(true)
+        }
     }
 
     private fun throwStartFailure(failure: Throwable): Nothing {

--- a/dadb/src/main/kotlin/dadb/forwarding/TcpForwarder.kt
+++ b/dadb/src/main/kotlin/dadb/forwarding/TcpForwarder.kt
@@ -1,163 +1,42 @@
 package dadb.forwarding
 
 import dadb.Dadb
-import dadb.log
-import okio.BufferedSink
-import okio.Source
 import okio.buffer
 import okio.sink
 import okio.source
-import java.io.IOException
-import java.io.InterruptedIOException
 import java.net.ServerSocket
-import java.net.SocketException
-import java.util.concurrent.ExecutorService
-import java.util.concurrent.Executors
-import java.util.concurrent.TimeUnit
-import java.util.concurrent.TimeoutException
-import kotlin.concurrent.thread
 
 internal class TcpForwarder(
-    private val dadb: Dadb,
+    dadb: Dadb,
     private val hostPort: Int,
-    private val targetPort: Int,
-) : AutoCloseable {
+    remoteDestination: String,
+) : BaseForwarder(
+    dadb = dadb,
+    remoteDestination = remoteDestination,
+    endpointDescription = "port $hostPort",
+    forwardingType = "TCP",
+) {
 
-    private var state: State = State.STOPPED
-    private var serverThread: Thread? = null
-    private var server: ServerSocket? = null
-    private var clientExecutor: ExecutorService? = null
+    override fun createServer(): ForwardingServer = TcpServerAdapter(hostPort)
 
-    fun start() {
-        check(state == State.STOPPED) { "Forwarder is already started at port $hostPort" }
+    private class TcpServerAdapter(port: Int) : ForwardingServer {
+        private val delegate = ServerSocket(port)
 
-        moveToState(State.STARTING)
+        override fun accept(): ForwardingClient = TcpClientAdapter(delegate.accept())
 
-        clientExecutor = Executors.newCachedThreadPool()
-        serverThread = thread {
-            try {
-                handleForwarding()
-            } catch (ignored: SocketException) {
-                // Do nothing
-            } catch (e: IOException) {
-                log { "could not start TCP port forwarding: ${e.message}" }
-            } finally {
-                moveToState(State.STOPPED)
-            }
-        }
-
-        waitFor(10, 5000) {
-            state == State.STARTED
+        override fun close() {
+            delegate.close()
         }
     }
 
-    private fun handleForwarding() {
-        val serverRef = ServerSocket(hostPort)
-        server = serverRef
+    private class TcpClientAdapter(
+        private val delegate: java.net.Socket,
+    ) : ForwardingClient {
+        override val source = delegate.getInputStream().source()
+        override val sink = delegate.sink().buffer()
 
-        moveToState(State.STARTED)
-
-        while (!Thread.interrupted()) {
-            val client = serverRef.accept()
-
-            clientExecutor?.execute {
-                val adbStream = dadb.open("tcp:$targetPort")
-
-                val readerThread = thread {
-                    forward(
-                        client.getInputStream().source(),
-                        adbStream.sink
-                    )
-                }
-
-                try {
-                    forward(
-                        adbStream.source,
-                        client.sink().buffer()
-                    )
-                } finally {
-                    adbStream.close()
-                    client.close()
-
-                    readerThread.interrupt()
-                }
-            }
+        override fun close() {
+            delegate.close()
         }
     }
-
-    override fun close() {
-        if (state == State.STOPPED || state == State.STOPPING) {
-            return
-        }
-
-        // Make sure that we are not stopping the server while it is in a transient state
-        // to avoid surprises
-        waitFor(10, 5000) {
-            state == State.STARTED
-        }
-
-        moveToState(State.STOPPING)
-
-        server?.close()
-        server = null
-        serverThread?.interrupt()
-        serverThread = null
-        clientExecutor?.shutdown()
-        clientExecutor?.awaitTermination(5, TimeUnit.SECONDS)
-        clientExecutor = null
-
-        waitFor(10, 5000) {
-            state == State.STOPPED
-        }
-    }
-
-    private fun forward(source: Source, sink: BufferedSink) {
-        try {
-            while (!Thread.interrupted()) {
-                try {
-                    if (source.read(sink.buffer, 256) >= 0) {
-                        sink.flush()
-                    } else {
-                        return
-                    }
-                } catch (ignored: IOException) {
-                    // Do nothing
-                }
-            }
-        } catch (ignored: InterruptedException) {
-            // Do nothing
-        } catch (ignored: InterruptedIOException) {
-            // do nothing
-        }
-    }
-
-    private fun moveToState(state: State) {
-        this.state = state
-    }
-
-    private enum class State {
-        STARTING,
-        STARTED,
-        STOPPING,
-        STOPPED
-    }
-
-    private fun waitFor(intervalMs: Int, timeoutMs: Int, test: () -> Boolean) {
-        val start = System.currentTimeMillis()
-        var lastCheck = start
-        while (!test()) {
-            val now = System.currentTimeMillis()
-            val timeSinceStart = now - start
-            val timeSinceLastCheck = now - lastCheck
-            if (timeoutMs in 0..timeSinceStart) {
-                throw TimeoutException()
-            }
-            val sleepTime = intervalMs - timeSinceLastCheck
-            if (sleepTime > 0) {
-                Thread.sleep(sleepTime)
-            }
-            lastCheck = System.currentTimeMillis()
-        }
-    }
-
 }

--- a/dadb/src/main/kotlin/dadb/helper/RemoteAppIconHelper.kt
+++ b/dadb/src/main/kotlin/dadb/helper/RemoteAppIconHelper.kt
@@ -1,0 +1,432 @@
+package dadb.helper
+
+import dadb.Dadb
+import okio.ByteString.Companion.decodeBase64
+import okio.ByteString.Companion.toByteString
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.io.IOException
+import java.util.zip.ZipInputStream
+
+class RemoteAppIconData(
+    val label: String,
+    val iconHash: String,
+    val imageBytes: ByteArray?,
+    val changed: Boolean,
+)
+
+data class RemoteAppIconBatchRequest(
+    val packageName: String,
+    val localHash: String?,
+)
+
+class RemoteChangedAppIcon(
+    val packageName: String,
+    val label: String,
+    val iconHash: String,
+    val imageBytes: ByteArray?,
+)
+
+data class RemoteAppIconBatchData(
+    val entries: List<RemoteChangedAppIcon>,
+)
+
+data class RemoteAppListItem(
+    val packageName: String,
+    val label: String,
+    val enabled: Boolean,
+    val systemApp: Boolean,
+    val sourceDir: String,
+    val versionCode: Long,
+    val lastUpdateTime: Long,
+)
+
+data class RemoteHelperProbeResult(
+    val command: String,
+    val exitCode: Int,
+    val stdout: String,
+    val stderr: String,
+)
+
+data class RemoteHelperFileState(
+    val exists: Boolean,
+    val detail: String,
+)
+
+private const val DEFAULT_REMOTE_HELPER_PATH = "/data/local/tmp/dadb-icon-helper-v3.jar"
+
+@Throws(IOException::class)
+fun Dadb.loadAppIconWithHelper(
+    packageName: String,
+    localHash: String? = null,
+    localHelperJar: File,
+    remoteHelperPath: String = DEFAULT_REMOTE_HELPER_PATH,
+): RemoteAppIconData {
+    require(localHelperJar.exists()) { "Local helper jar not found: ${localHelperJar.absolutePath}" }
+
+    val response =
+        invokeRemoteHelper(
+            args =
+                buildList {
+                    add("icon")
+                    add(packageName)
+                    localHash?.takeIf { it.isNotBlank() }?.let(::add)
+                },
+            remoteHelperPath = remoteHelperPath,
+        )
+
+    if (response.exitCode != 0) {
+        throw IOException(
+            buildString {
+                append("Remote app icon helper failed")
+                append(" (exit=")
+                append(response.exitCode)
+                append(")")
+                val stdout = response.output.trim()
+                if (stdout.isNotBlank()) {
+                    append(" stdout=")
+                    append(stdout)
+                }
+                val stderr = response.errorOutput.trim()
+                if (stderr.isNotBlank()) {
+                    append(" stderr=")
+                    append(stderr)
+                }
+            },
+        )
+    }
+
+    val lines =
+        response.output
+            .lineSequence()
+            .map(String::trim)
+            .filter(String::isNotBlank)
+            .toList()
+
+    if (lines.size < 3) {
+        throw IOException("Remote app icon helper returned unexpected output")
+    }
+
+    val changed = lines[0] == "CHANGED"
+    val iconHash = lines[1]
+    val label =
+        String(
+            lines[2].decodeBase64()?.toByteArray()
+                ?: throw IOException("Remote app icon helper returned invalid label payload"),
+            Charsets.UTF_8,
+        )
+    val imageBytes =
+        if (changed) {
+            lines.getOrNull(3)?.decodeBase64()?.toByteArray()
+                ?: throw IOException("Remote app icon helper missing changed icon payload")
+        } else {
+            null
+        }
+
+    return RemoteAppIconData(
+        label = label,
+        iconHash = iconHash,
+        imageBytes = imageBytes,
+        changed = changed,
+    )
+}
+
+@Throws(IOException::class)
+fun Dadb.loadAppIconBatchWithHelper(
+    requests: List<RemoteAppIconBatchRequest>,
+    localHelperJar: File,
+    remoteHelperPath: String = DEFAULT_REMOTE_HELPER_PATH,
+): RemoteAppIconBatchData {
+    require(localHelperJar.exists()) { "Local helper jar not found: ${localHelperJar.absolutePath}" }
+    if (requests.isEmpty()) {
+        return RemoteAppIconBatchData(entries = emptyList())
+    }
+
+    val requestPayload =
+        requests.joinToString(separator = "\n") { request ->
+            buildString {
+                append(request.packageName)
+                append('\t')
+                append(request.localHash.orEmpty())
+            }
+        }
+    val encodedRequest = requestPayload.toByteArray(Charsets.UTF_8).toByteString().base64()
+
+    val response =
+        invokeRemoteHelper(
+            args = listOf("icons", encodedRequest),
+            remoteHelperPath = remoteHelperPath,
+        )
+
+    if (response.exitCode != 0) {
+        throw IOException(
+            buildString {
+                append("Remote app icon batch helper failed")
+                append(" (exit=")
+                append(response.exitCode)
+                append(")")
+                val stdout = response.output.trim()
+                if (stdout.isNotBlank()) {
+                    append(" stdout=")
+                    append(stdout)
+                }
+                val stderr = response.errorOutput.trim()
+                if (stderr.isNotBlank()) {
+                    append(" stderr=")
+                    append(stderr)
+                }
+            },
+        )
+    }
+
+    val lines =
+        response.output
+            .lineSequence()
+            .map(String::trim)
+            .filter(String::isNotBlank)
+            .toList()
+
+    if (lines.size < 3 || lines[0] != "BATCH") {
+        throw IOException("Remote app icon batch helper returned unexpected output")
+    }
+
+    val manifestLines =
+        if (lines[1] == "-") {
+            emptyList()
+        } else {
+            String(
+                lines[1].decodeBase64()?.toByteArray()
+                    ?: throw IOException("Remote app icon batch helper returned invalid manifest payload"),
+                Charsets.UTF_8,
+            ).lineSequence()
+                .map(String::trim)
+                .filter(String::isNotBlank)
+                .toList()
+        }
+
+    if (manifestLines.isEmpty()) {
+        return RemoteAppIconBatchData(entries = emptyList())
+    }
+
+    val zipEntries =
+        if (lines[2] == "-") {
+            emptyMap()
+        } else {
+            unzipEntries(
+                lines[2].decodeBase64()?.toByteArray()
+                    ?: throw IOException("Remote app icon batch helper returned invalid zip payload"),
+            )
+        }
+    val entries =
+        manifestLines.map { line ->
+            val parts = line.split('\t')
+            if (parts.size < 4) {
+                throw IOException("Remote app icon batch helper returned unexpected manifest line: $line")
+            }
+            val packageName = parts[0]
+            val label =
+                String(
+                    parts[1].decodeBase64()?.toByteArray()
+                        ?: throw IOException("Remote app icon batch helper returned invalid label payload"),
+                    Charsets.UTF_8,
+                )
+            val iconHash = parts[2]
+            val entryName = parts[3]
+            val bytes =
+                if (entryName == "-") {
+                    null
+                } else {
+                    zipEntries[entryName]
+                        ?: throw IOException("Remote app icon batch helper missing zip entry: $entryName")
+                }
+            RemoteChangedAppIcon(
+                packageName = packageName,
+                label = label,
+                iconHash = iconHash,
+                imageBytes = bytes,
+            )
+        }
+
+    return RemoteAppIconBatchData(entries = entries)
+}
+
+@Throws(IOException::class)
+fun Dadb.loadAppListPageWithHelper(
+    offset: Int,
+    limit: Int,
+    includeSystem: Boolean,
+    localHelperJar: File,
+    remoteHelperPath: String = DEFAULT_REMOTE_HELPER_PATH,
+): List<RemoteAppListItem> {
+    require(localHelperJar.exists()) { "Local helper jar not found: ${localHelperJar.absolutePath}" }
+
+    val response =
+        invokeRemoteHelper(
+            args = listOf("list", offset.toString(), limit.toString(), if (includeSystem) "1" else "0"),
+            remoteHelperPath = remoteHelperPath,
+        )
+
+    if (response.exitCode != 0) {
+        throw IOException(
+            buildString {
+                append("Remote app list helper failed")
+                append(" (exit=")
+                append(response.exitCode)
+                append(")")
+                val stdout = response.output.trim()
+                if (stdout.isNotBlank()) {
+                    append(" stdout=")
+                    append(stdout)
+                }
+                val stderr = response.errorOutput.trim()
+                if (stderr.isNotBlank()) {
+                    append(" stderr=")
+                    append(stderr)
+                }
+            },
+        )
+    }
+
+    return response.output
+        .lineSequence()
+        .map(String::trim)
+        .filter(String::isNotBlank)
+        .map { line ->
+            val parts = line.split('\t')
+            if (parts.size < 7) {
+                throw IOException("Remote app list helper returned unexpected line: $line")
+            }
+            RemoteAppListItem(
+                packageName = parts[0],
+                label =
+                    String(
+                        parts[1].decodeBase64()?.toByteArray()
+                            ?: throw IOException("Remote app list helper returned invalid label payload"),
+                        Charsets.UTF_8,
+                    ),
+                enabled = parts[2] == "1",
+                systemApp = parts[3] == "1",
+                sourceDir =
+                    String(
+                        parts[4].decodeBase64()?.toByteArray()
+                            ?: throw IOException("Remote app list helper returned invalid sourceDir payload"),
+                        Charsets.UTF_8,
+                    ),
+                versionCode = parts[5].toLongOrNull() ?: 0L,
+                lastUpdateTime = parts[6].toLongOrNull() ?: 0L,
+            )
+        }.toList()
+}
+
+@Throws(IOException::class)
+fun Dadb.ensureRemoteAppIconHelper(
+    localHelperJar: File,
+    remoteHelperPath: String = DEFAULT_REMOTE_HELPER_PATH,
+) {
+    push(localHelperJar, remoteHelperPath) // 每次都覆盖
+    val exists =
+        runCatching {
+            shell("test -f ${shellQuote(remoteHelperPath)} && echo 1 || echo 0")
+                .output
+                .trim()
+                .equals("1")
+        }.getOrNull()
+
+    if (exists != true) {
+        push(localHelperJar, remoteHelperPath)
+    }
+}
+
+@Throws(IOException::class)
+fun Dadb.prepareRemoteAppIconHelper(
+    localHelperJar: File,
+    remoteHelperPath: String = DEFAULT_REMOTE_HELPER_PATH,
+): RemoteHelperFileState {
+    require(localHelperJar.exists()) { "Local helper jar not found: ${localHelperJar.absolutePath}" }
+    val beforeState = inspectRemoteAppHelperFile(remoteHelperPath)
+    if (!beforeState.exists) {
+        ensureRemoteAppIconHelper(localHelperJar, remoteHelperPath)
+        return inspectRemoteAppHelperFile(remoteHelperPath)
+    }
+    return beforeState
+}
+
+@Throws(IOException::class)
+fun Dadb.inspectRemoteAppHelperFile(remoteHelperPath: String = DEFAULT_REMOTE_HELPER_PATH): RemoteHelperFileState {
+    val response =
+        shell(
+            "if [ -f ${shellQuote(remoteHelperPath)} ]; then " +
+                "echo EXISTS; ls -l ${shellQuote(remoteHelperPath)}; " +
+                "else echo MISSING; fi",
+        )
+    val stdout = response.output.trim()
+    val exists = stdout.lineSequence().firstOrNull() == "EXISTS"
+    return RemoteHelperFileState(
+        exists = exists,
+        detail = stdout,
+    )
+}
+
+@Throws(IOException::class)
+fun Dadb.runRemoteAppHelperProbe(
+    command: String,
+    args: List<String> = emptyList(),
+    localHelperJar: File,
+    remoteHelperPath: String = DEFAULT_REMOTE_HELPER_PATH,
+): RemoteHelperProbeResult {
+    require(localHelperJar.exists()) { "Local helper jar not found: ${localHelperJar.absolutePath}" }
+    prepareRemoteAppIconHelper(localHelperJar, remoteHelperPath)
+    val response = invokeRemoteHelper(listOf(command) + args, remoteHelperPath)
+    return RemoteHelperProbeResult(
+        command =
+            buildString {
+                append(command)
+                if (args.isNotEmpty()) {
+                    append(' ')
+                    append(args.joinToString(" "))
+                }
+            },
+        exitCode = response.exitCode,
+        stdout = response.output.trim(),
+        stderr = response.errorOutput.trim(),
+    )
+}
+
+private fun Dadb.invokeRemoteHelper(
+    args: List<String>,
+    remoteHelperPath: String,
+) = shell(
+    buildString {
+        append("CLASSPATH=")
+        append(shellQuote(remoteHelperPath))
+        append(" app_process / dadb.helper.AppIconExportMain")
+        args.forEach { arg ->
+            append(' ')
+            append(shellQuote(arg))
+        }
+    },
+)
+
+private fun unzipEntries(zipBytes: ByteArray): Map<String, ByteArray> {
+    val entries = linkedMapOf<String, ByteArray>()
+    ZipInputStream(ByteArrayInputStream(zipBytes)).use { input ->
+        while (true) {
+            val entry = input.nextEntry ?: break
+            val output = ByteArrayOutputStream()
+            val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+            while (true) {
+                val read = input.read(buffer)
+                if (read < 0) {
+                    break
+                }
+                output.write(buffer, 0, read)
+            }
+            entries[entry.name] = output.toByteArray()
+            input.closeEntry()
+        }
+    }
+    return entries
+}
+
+private fun shellQuote(value: String): String = "'${value.replace("'", "'\"'\"'")}'"

--- a/dadb/src/test/kotlin/dadb/AdbConnectionTransportTest.kt
+++ b/dadb/src/test/kotlin/dadb/AdbConnectionTransportTest.kt
@@ -23,7 +23,12 @@ import okio.Buffer
 import okio.Sink
 import okio.Source
 import okio.Timeout
+import java.io.IOException
+import java.util.ArrayDeque
 import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
 
 internal class AdbConnectionTransportTest {
 
@@ -51,6 +56,45 @@ internal class AdbConnectionTransportTest {
         val connectMessage = AdbReader(hostWrites).readMessage()
         assertThat(connectMessage.command).isEqualTo(Constants.CMD_CNXN)
         assertThat(connectMessage.arg1).isEqualTo(15 * 1024)
+        assertThat(connectMessage.arg0).isEqualTo(Constants.CONNECT_VERSION)
+        assertThat(String(connectMessage.payload)).isEqualTo(String(Constants.CONNECT_PAYLOAD))
+        assertThat(String(connectMessage.payload)).contains(Constants.FEATURE_DELAYED_ACK)
+    }
+
+    @Test
+    fun open_delayedAckNegotiatesInitialWindows() {
+        val deviceResponse = Buffer()
+        val responsePayload = "device::features=shell_v2,delayed_ack".toByteArray()
+        val deviceWriter = AdbWriter(deviceResponse)
+        deviceWriter.write(
+            Constants.CMD_CNXN,
+            Constants.CONNECT_VERSION,
+            4096,
+            responsePayload,
+            0,
+            responsePayload.size,
+        )
+        val hostWrites = Buffer()
+        var capturedOpenMessage: AdbMessage? = null
+        val transport = SourceSinkAdbTransport(
+            source = deviceResponse,
+            sink = ReplyingSink(hostWrites) { message ->
+                if (message.command == Constants.CMD_OPEN) {
+                    capturedOpenMessage = message
+                    AdbWriter(deviceResponse).writeOkay(2, message.arg0, 8192)
+                }
+            },
+            description = "usb:test",
+        )
+
+        AdbConnection.connect(transport).use { connection ->
+            connection.open("shell:echo delayed_ack").close()
+        }
+
+        val openMessage = checkNotNull(capturedOpenMessage)
+        assertThat(openMessage.command).isEqualTo(Constants.CMD_OPEN)
+        assertThat(openMessage.arg1).isEqualTo(Constants.INITIAL_DELAYED_ACK_BYTES)
+        assertThat(String(openMessage.payload, 0, openMessage.payloadLength - 1)).isEqualTo("shell:echo delayed_ack")
     }
 
     @Test
@@ -107,6 +151,265 @@ internal class AdbConnectionTransportTest {
 
         assertThat(source.closed).isTrue()
         assertThat(sink.closed).isTrue()
+    }
+
+    @Test
+    fun connect_missingFeatures_defaultsToEmptyFeatureSet() {
+        val deviceResponse = Buffer()
+        val responsePayload = "device::ro.product.name=sdk".toByteArray()
+        AdbWriter(deviceResponse).write(
+            Constants.CMD_CNXN,
+            Constants.CONNECT_VERSION,
+            4096,
+            responsePayload,
+            0,
+            responsePayload.size,
+        )
+
+        val hostWrites = Buffer()
+        val transport = SourceSinkAdbTransport(deviceResponse, hostWrites, "usb:test")
+
+        AdbConnection.connect(transport).use { connection ->
+            assertThat(connection.supportsFeature("shell_v2")).isFalse()
+            assertThat(connection.isTlsConnection()).isFalse()
+        }
+    }
+
+    @Test
+    fun connect_preservesPeerFeaturesForCapabilityChecks() {
+        val deviceResponse = Buffer()
+        val responsePayload = "device::features=shell_v2,stat_v2".toByteArray()
+        AdbWriter(deviceResponse).write(
+            Constants.CMD_CNXN,
+            Constants.CONNECT_VERSION,
+            4096,
+            responsePayload,
+            0,
+            responsePayload.size,
+        )
+
+        val hostWrites = Buffer()
+        val transport = SourceSinkAdbTransport(deviceResponse, hostWrites, "usb:test")
+
+        AdbConnection.connect(transport).use { connection ->
+            assertThat(connection.supportsFeature("shell_v2")).isTrue()
+            assertThat(connection.supportsFeature("stat_v2")).isTrue()
+        }
+    }
+
+    @Test
+    fun reader_rejectsInvalidMagic() {
+        val input = Buffer()
+        input.writeIntLe(Constants.CMD_CNXN)
+        input.writeIntLe(Constants.CONNECT_VERSION)
+        input.writeIntLe(Constants.CONNECT_MAXDATA)
+        input.writeIntLe(0)
+        input.writeIntLe(0)
+        input.writeIntLe(0)
+
+        val error = assertFailsWith<IOException> {
+            AdbReader(input).readMessage()
+        }
+
+        assertThat(error).hasMessageThat().contains("Invalid ADB magic")
+    }
+
+    @Test
+    fun reader_rejectsPayloadLargerThanLimit() {
+        val input = Buffer()
+        val payload = "oversized".toByteArray()
+        AdbWriter(input).write(
+            Constants.CMD_CNXN,
+            Constants.CONNECT_VERSION,
+            Constants.CONNECT_MAXDATA,
+            payload,
+            0,
+            payload.size,
+        )
+
+        val error = assertFailsWith<IOException> {
+            AdbReader(input, maxPayloadSize = 4).readMessage()
+        }
+
+        assertThat(error).hasMessageThat().contains("Invalid ADB payload length")
+    }
+
+    @Test
+    fun connect_rejectsPreNegotiationPayloadLargerThanV1Limit() {
+        val deviceResponse = Buffer()
+        val payload = ByteArray(Constants.MAX_PAYLOAD_V1 + 1)
+        AdbWriter(deviceResponse).write(
+            Constants.CMD_CNXN,
+            Constants.CONNECT_VERSION,
+            Constants.CONNECT_MAXDATA,
+            payload,
+            0,
+            payload.size,
+        )
+
+        val transport = SourceSinkAdbTransport(deviceResponse, Buffer(), "usb:test")
+
+        val error = assertFailsWith<IOException> {
+            AdbConnection.connect(transport)
+        }
+
+        assertThat(error).hasMessageThat().contains("Invalid ADB payload length")
+    }
+
+    @Test
+    fun connect_rejectsInvalidPeerMaxData() {
+        val deviceResponse = Buffer()
+        val responsePayload = "device::features=shell_v2".toByteArray()
+        AdbWriter(deviceResponse).write(
+            Constants.CMD_CNXN,
+            Constants.CONNECT_VERSION,
+            0,
+            responsePayload,
+            0,
+            responsePayload.size,
+        )
+
+        val transport = SourceSinkAdbTransport(deviceResponse, Buffer(), "usb:test")
+
+        val error = assertFailsWith<IOException> {
+            AdbConnection.connect(transport)
+        }
+
+        assertThat(error).hasMessageThat().contains("Peer maxdata must be > 0")
+    }
+
+    @Test
+    fun parseReverseTcpTarget_defaultsToLoopback() {
+        assertEquals(ReverseTcpTarget("127.0.0.1", 27183), parseReverseTcpTarget("tcp:27183"))
+    }
+
+    @Test
+    fun parseReverseTcpTarget_supportsExplicitHost() {
+        assertEquals(ReverseTcpTarget("localhost", 27183), parseReverseTcpTarget("tcp:localhost:27183"))
+    }
+
+    @Test
+    fun parseReverseTcpTarget_rejectsInvalidInput() {
+        assertNull(parseReverseTcpTarget("localabstract:scrcpy"))
+        assertNull(parseReverseTcpTarget("tcp:"))
+        assertNull(parseReverseTcpTarget("tcp:0"))
+        assertNull(parseReverseTcpTarget("tcp:host:not-a-port"))
+        assertNull(parseReverseTcpTarget("tcp:host:70000"))
+    }
+
+    @Test
+    fun parseAdbServiceResponse_decodesOkayPayload() {
+        val response = parseAdbServiceResponse("OKAY0004test")
+        assertEquals(AdbServiceStatus.OKAY, response.status)
+        assertEquals("test", response.payload)
+    }
+
+    @Test
+    fun parseAdbServiceResponse_decodesFailPayload() {
+        val response = parseAdbServiceResponse("FAIL0007failure")
+        assertEquals(AdbServiceStatus.FAIL, response.status)
+        assertEquals("failure", response.payload)
+    }
+
+    @Test
+    fun parseReverseListOutput_supportsHostPrefixedRows() {
+        val rules = parseReverseListOutput("host tcp:27183 tcp:12345\n")
+        assertThat(rules).containsExactly(AdbReverseRule(device = "tcp:27183", host = "tcp:12345"))
+    }
+
+    @Test
+    fun reverseForward_rejectsUnsupportedHostDestination() {
+        val dadb =
+            object : Dadb {
+                override fun open(destination: String): AdbStream {
+                    error("open should not be called for invalid reverse destinations")
+                }
+
+                override fun supportsFeature(feature: String): Boolean = false
+
+                override fun isTlsConnection(): Boolean = false
+
+                override fun close() = Unit
+            }
+
+        val error = assertFailsWith<IllegalArgumentException> {
+            dadb.reverseForward("localabstract:scrcpy", "localabstract:host")
+        }
+
+        assertThat(error).hasMessageThat().contains("supports only tcp")
+    }
+
+    @Test
+    fun buildReverseForwardDestination_supportsLocalAbstractDeviceAndTcpHost() {
+        assertEquals(
+            "reverse:forward:localabstract:scrcpy_123;tcp:27183",
+            buildReverseForwardDestination("localabstract:scrcpy_123", "tcp:27183"),
+        )
+    }
+
+    @Test
+    fun reverseForward_noRebind_usesNoRebindServiceAndReturnsPayload() {
+        val dadb = RecordingDadb("OKAY000527183")
+
+        val assignedPort = dadb.reverseForward("tcp:0", "tcp:27183", noRebind = true)
+
+        assertThat(assignedPort).isEqualTo("27183")
+        assertThat(dadb.openDestinations).containsExactly("reverse:forward:norebind:tcp:0;tcp:27183")
+    }
+
+    @Test
+    fun reverseForward_blankOkayPayload_returnsNull() {
+        val dadb = RecordingDadb("OKAY")
+
+        val assignedPort = dadb.reverseForward(27183, 27184)
+
+        assertNull(assignedPort)
+        assertThat(dadb.openDestinations).containsExactly("reverse:forward:tcp:27183;tcp:27184")
+    }
+
+    @Test
+    fun reverseKillForward_usesExpectedServiceDestination() {
+        val dadb = RecordingDadb("OKAY")
+
+        dadb.reverseKillForward("tcp:27183")
+
+        assertThat(dadb.openDestinations).containsExactly("reverse:killforward:tcp:27183")
+    }
+
+    @Test
+    fun reverseKillAllForwards_usesExpectedServiceDestination() {
+        val dadb = RecordingDadb("OKAY")
+
+        dadb.reverseKillAllForwards()
+
+        assertThat(dadb.openDestinations).containsExactly("reverse:killforward-all")
+    }
+
+    @Test
+    fun reverseListForwards_parsesServiceOutput() {
+        val dadb =
+            RecordingDadb(
+                "OKAYhost-19 tcp:27183 tcp:12345\nhost-19 localabstract:scrcpy tcp:27184\n",
+            )
+
+        val rules = dadb.reverseListForwards()
+
+        assertThat(rules).containsExactly(
+            AdbReverseRule(device = "tcp:27183", host = "tcp:12345"),
+            AdbReverseRule(device = "localabstract:scrcpy", host = "tcp:27184"),
+        )
+        assertThat(dadb.openDestinations).containsExactly("reverse:list-forward")
+    }
+
+    @Test
+    fun executeAdbService_failResponseThrowsIOException() {
+        val dadb = RecordingDadb("FAIL0007failure")
+
+        val error = assertFailsWith<IOException> {
+            dadb.reverseKillAllForwards()
+        }
+
+        assertThat(error).hasMessageThat().contains("failure")
     }
 }
 
@@ -173,4 +476,49 @@ private class TrackingSink : Sink {
     override fun close() {
         closed = true
     }
+}
+
+private class ReplyingSink(
+    private val delegate: Buffer,
+    private val onMessage: (AdbMessage) -> Unit,
+) : Sink {
+    override fun write(source: Buffer, byteCount: Long) {
+        val bytes = source.readByteArray(byteCount)
+        delegate.write(bytes)
+        onMessage(AdbReader(Buffer().write(bytes)).readMessage())
+    }
+
+    override fun flush() = Unit
+
+    override fun timeout(): Timeout = Timeout.NONE
+
+    override fun close() = Unit
+}
+
+private class RecordingDadb(
+    vararg serviceResponses: String,
+) : Dadb {
+    val openDestinations = mutableListOf<String>()
+    private val pendingResponses = ArrayDeque(serviceResponses.toList())
+
+    override fun open(destination: String): AdbStream {
+        openDestinations += destination
+        val response = if (pendingResponses.isEmpty()) error("No queued response for destination: $destination") else pendingResponses.removeFirst()
+        return FakeAdbStream(response)
+    }
+
+    override fun supportsFeature(feature: String): Boolean = false
+
+    override fun isTlsConnection(): Boolean = false
+
+    override fun close() = Unit
+}
+
+private class FakeAdbStream(
+    response: String,
+) : AdbStream {
+    override val source = Buffer().writeUtf8(response)
+    override val sink = Buffer()
+
+    override fun close() = Unit
 }

--- a/dadb/src/test/kotlin/dadb/AdbConnectionTransportTest.kt
+++ b/dadb/src/test/kotlin/dadb/AdbConnectionTransportTest.kt
@@ -20,6 +20,9 @@ package dadb
 
 import com.google.common.truth.Truth.assertThat
 import okio.Buffer
+import okio.Sink
+import okio.Source
+import okio.Timeout
 import kotlin.test.Test
 
 internal class AdbConnectionTransportTest {
@@ -42,10 +45,132 @@ internal class AdbConnectionTransportTest {
 
         AdbConnection.connect(transport).use { connection ->
             assertThat(connection.supportsFeature("shell_v2")).isTrue()
+            assertThat(connection.isTlsConnection()).isFalse()
         }
 
         val connectMessage = AdbReader(hostWrites).readMessage()
         assertThat(connectMessage.command).isEqualTo(Constants.CMD_CNXN)
         assertThat(connectMessage.arg1).isEqualTo(15 * 1024)
+    }
+
+    @Test
+    fun connect_stlsUpgrade() {
+        val rawDeviceResponse = Buffer()
+        AdbWriter(rawDeviceResponse).write(
+            Constants.CMD_STLS,
+            Constants.STLS_VERSION,
+            0,
+            null,
+            0,
+            0,
+        )
+
+        val upgradedDeviceResponse = Buffer()
+        val responsePayload = "device::features=shell_v2".toByteArray()
+        AdbWriter(upgradedDeviceResponse).write(
+            Constants.CMD_CNXN,
+            Constants.CONNECT_VERSION,
+            4096,
+            responsePayload,
+            0,
+            responsePayload.size,
+        )
+
+        val rawHostWrites = Buffer()
+        val upgradedHostWrites = Buffer()
+        val transport =
+            FakeTlsTransport(
+                rawSource = rawDeviceResponse,
+                rawSink = rawHostWrites,
+                upgradedSource = upgradedDeviceResponse,
+                upgradedSink = upgradedHostWrites,
+            )
+
+        AdbConnection.connect(transport).use { connection ->
+            assertThat(connection.supportsFeature("shell_v2")).isTrue()
+            assertThat(connection.isTlsConnection()).isTrue()
+        }
+
+        assertThat(transport.upgraded).isTrue()
+        assertThat(transport.upgradeVersion).isEqualTo(Constants.STLS_VERSION)
+        assertThat(transport.rawConnectSeen).isTrue()
+        assertThat(transport.rawStlsSeen).isTrue()
+    }
+
+    @Test
+    fun sourceSinkTransport_closeWithoutCloseable_closesSourceAndSink() {
+        val source = TrackingSource()
+        val sink = TrackingSink()
+        val transport = SourceSinkAdbTransport(source, sink, "test")
+
+        transport.close()
+
+        assertThat(source.closed).isTrue()
+        assertThat(sink.closed).isTrue()
+    }
+}
+
+private class FakeTlsTransport(
+    private val rawSource: Source,
+    private val rawSink: Buffer,
+    private val upgradedSource: Source,
+    private val upgradedSink: Buffer,
+) : TlsUpgradableAdbTransport {
+    var upgraded = false
+        private set
+
+    var upgradeVersion: Int? = null
+        private set
+
+    var rawConnectSeen = false
+        private set
+
+    var rawStlsSeen = false
+        private set
+
+    override val source: Source
+        get() = if (upgraded) upgradedSource else rawSource
+
+    override val sink: Sink
+        get() = if (upgraded) upgradedSink else rawSink
+
+    override val isClosed: Boolean = false
+
+    override fun upgradeToTls(version: Int) {
+        val reader = AdbReader(rawSink)
+        rawConnectSeen = reader.readMessage().command == Constants.CMD_CNXN
+        rawStlsSeen = reader.readMessage().command == Constants.CMD_STLS
+        upgraded = true
+        upgradeVersion = version
+    }
+
+    override fun close() = Unit
+}
+
+private class TrackingSource : Source {
+    var closed = false
+        private set
+
+    override fun read(sink: Buffer, byteCount: Long): Long = -1
+
+    override fun timeout(): Timeout = Timeout.NONE
+
+    override fun close() {
+        closed = true
+    }
+}
+
+private class TrackingSink : Sink {
+    var closed = false
+        private set
+
+    override fun write(source: Buffer, byteCount: Long) = Unit
+
+    override fun flush() = Unit
+
+    override fun timeout(): Timeout = Timeout.NONE
+
+    override fun close() {
+        closed = true
     }
 }

--- a/dadb/src/test/kotlin/dadb/AdbConnectionTransportTest.kt
+++ b/dadb/src/test/kotlin/dadb/AdbConnectionTransportTest.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2021 mobile.dev inc.
+ * Additional transport support by github.com/XRSec/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package dadb
+
+import com.google.common.truth.Truth.assertThat
+import okio.Buffer
+import kotlin.test.Test
+
+internal class AdbConnectionTransportTest {
+
+    @Test
+    fun connect_customMaxData() {
+        val deviceResponse = Buffer()
+        val responsePayload = "device::features=shell_v2".toByteArray()
+        AdbWriter(deviceResponse).write(
+            Constants.CMD_CNXN,
+            Constants.CONNECT_VERSION,
+            4096,
+            responsePayload,
+            0,
+            responsePayload.size,
+        )
+
+        val hostWrites = Buffer()
+        val transport = SourceSinkAdbTransport(deviceResponse, hostWrites, "usb:test", 15 * 1024)
+
+        AdbConnection.connect(transport).use { connection ->
+            assertThat(connection.supportsFeature("shell_v2")).isTrue()
+        }
+
+        val connectMessage = AdbReader(hostWrites).readMessage()
+        assertThat(connectMessage.command).isEqualTo(Constants.CMD_CNXN)
+        assertThat(connectMessage.arg1).isEqualTo(15 * 1024)
+    }
+}

--- a/dadb/src/test/kotlin/dadb/AdbConnectionTransportTest.kt
+++ b/dadb/src/test/kotlin/dadb/AdbConnectionTransportTest.kt
@@ -98,6 +98,46 @@ internal class AdbConnectionTransportTest {
     }
 
     @Test
+    fun open_withoutRequestedDelayedAckDoesNotNegotiateInitialWindows() {
+        val deviceResponse = Buffer()
+        val responsePayload = "device::features=shell_v2,delayed_ack".toByteArray()
+        val deviceWriter = AdbWriter(deviceResponse)
+        deviceWriter.write(
+            Constants.CMD_CNXN,
+            Constants.CONNECT_VERSION,
+            4096,
+            responsePayload,
+            0,
+            responsePayload.size,
+        )
+        val hostWrites = Buffer()
+        var capturedOpenMessage: AdbMessage? = null
+        val transport = SourceSinkAdbTransport(
+            source = deviceResponse,
+            sink = ReplyingSink(hostWrites) { message ->
+                if (message.command == Constants.CMD_OPEN) {
+                    capturedOpenMessage = message
+                    AdbWriter(deviceResponse).writeOkay(2, message.arg0)
+                }
+            },
+            description = "usb:test",
+        )
+
+        AdbConnection.connect(
+            transport,
+            features = Dadb.connectFeatures(withDelayedAck = false),
+        ).use { connection ->
+            assertThat(connection.supportsFeature(Dadb.FEATURE_DELAYED_ACK)).isTrue()
+            connection.open("shell:echo no_delayed_ack").close()
+        }
+
+        val openMessage = checkNotNull(capturedOpenMessage)
+        assertThat(openMessage.command).isEqualTo(Constants.CMD_OPEN)
+        assertThat(openMessage.arg1).isEqualTo(0)
+        assertThat(String(openMessage.payload, 0, openMessage.payloadLength - 1)).isEqualTo("shell:echo no_delayed_ack")
+    }
+
+    @Test
     fun connect_stlsUpgrade() {
         val rawDeviceResponse = Buffer()
         AdbWriter(rawDeviceResponse).write(
@@ -329,8 +369,6 @@ internal class AdbConnectionTransportTest {
 
                 override fun isTlsConnection(): Boolean = false
 
-                override fun reconnect(withDelayedAck: Boolean) = Unit
-
                 override fun close() = Unit
             }
 
@@ -512,8 +550,6 @@ private class RecordingDadb(
     override fun supportsFeature(feature: String): Boolean = false
 
     override fun isTlsConnection(): Boolean = false
-
-    override fun reconnect(withDelayedAck: Boolean) = Unit
 
     override fun close() = Unit
 }

--- a/dadb/src/test/kotlin/dadb/AdbConnectionTransportTest.kt
+++ b/dadb/src/test/kotlin/dadb/AdbConnectionTransportTest.kt
@@ -321,7 +321,7 @@ internal class AdbConnectionTransportTest {
     fun reverseForward_rejectsUnsupportedHostDestination() {
         val dadb =
             object : Dadb {
-                override fun open(destination: String): AdbStream {
+                override fun open(destination: String, enableDelayedAck: Boolean): AdbStream {
                     error("open should not be called for invalid reverse destinations")
                 }
 
@@ -501,7 +501,7 @@ private class RecordingDadb(
     val openDestinations = mutableListOf<String>()
     private val pendingResponses = ArrayDeque(serviceResponses.toList())
 
-    override fun open(destination: String): AdbStream {
+    override fun open(destination: String, enableDelayedAck: Boolean): AdbStream {
         openDestinations += destination
         val response = if (pendingResponses.isEmpty()) error("No queued response for destination: $destination") else pendingResponses.removeFirst()
         return FakeAdbStream(response)

--- a/dadb/src/test/kotlin/dadb/AdbConnectionTransportTest.kt
+++ b/dadb/src/test/kotlin/dadb/AdbConnectionTransportTest.kt
@@ -321,13 +321,15 @@ internal class AdbConnectionTransportTest {
     fun reverseForward_rejectsUnsupportedHostDestination() {
         val dadb =
             object : Dadb {
-                override fun open(destination: String, enableDelayedAck: Boolean): AdbStream {
+                override fun open(destination: String): AdbStream {
                     error("open should not be called for invalid reverse destinations")
                 }
 
                 override fun supportsFeature(feature: String): Boolean = false
 
                 override fun isTlsConnection(): Boolean = false
+
+                override fun reconnect(withDelayedAck: Boolean) = Unit
 
                 override fun close() = Unit
             }
@@ -501,7 +503,7 @@ private class RecordingDadb(
     val openDestinations = mutableListOf<String>()
     private val pendingResponses = ArrayDeque(serviceResponses.toList())
 
-    override fun open(destination: String, enableDelayedAck: Boolean): AdbStream {
+    override fun open(destination: String): AdbStream {
         openDestinations += destination
         val response = if (pendingResponses.isEmpty()) error("No queued response for destination: $destination") else pendingResponses.removeFirst()
         return FakeAdbStream(response)
@@ -510,6 +512,8 @@ private class RecordingDadb(
     override fun supportsFeature(feature: String): Boolean = false
 
     override fun isTlsConnection(): Boolean = false
+
+    override fun reconnect(withDelayedAck: Boolean) = Unit
 
     override fun close() = Unit
 }

--- a/dadb/src/test/kotlin/dadb/AdbServerDeviceSmokeTest.kt
+++ b/dadb/src/test/kotlin/dadb/AdbServerDeviceSmokeTest.kt
@@ -1,0 +1,221 @@
+package dadb
+
+import com.google.common.truth.Truth.assertThat
+import dadb.adbserver.AdbServer
+import okio.buffer
+import okio.source
+import java.net.ServerSocket
+import java.net.Socket
+import java.net.SocketTimeoutException
+import java.util.concurrent.Callable
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import kotlin.random.Random
+import kotlin.test.Test
+
+internal class AdbServerDeviceSmokeTest {
+
+    private val serials =
+        configuredAdbServerTestSerials()
+            .filter { it in availableAdbDeviceSerials() }
+    private val executor = Executors.newCachedThreadPool()
+
+    @Test
+    fun shellSmoke() {
+        assertThat(serials).isNotEmpty()
+
+        serials.forEach { serial ->
+            withDevice(serial) { dadb ->
+                val response = dadb.shell("echo smoke-$serial")
+                assertThat(response.exitCode).isEqualTo(0)
+                assertThat(response.output.trim()).isEqualTo("smoke-$serial")
+            }
+        }
+    }
+
+    @Test
+    fun forwardSmoke() {
+        assertThat(serials).isNotEmpty()
+
+        serials.forEachIndexed { index, serial ->
+            withDevice(serial) { dadb ->
+                val devicePort = 39080 + index
+                val hostPort = 39180 + index
+                val expected = "FORWARD-$index"
+
+                dadb.forward(hostPort, "tcp:$devicePort").use {
+                    val future =
+                        executor.submit {
+                            dadb.shell("echo -e '$expected' | nc -lp $devicePort")
+                        }
+                    Thread.sleep(500)
+
+                    val result =
+                        Socket("localhost", hostPort).use { socket ->
+                            socket.source().buffer().readUtf8()
+                        }
+
+                    future.get(5, TimeUnit.SECONDS)
+                    assertThat(result.trim()).isEqualTo(expected)
+                }
+            }
+        }
+    }
+
+    @Test
+    fun reverseSmoke() {
+        assertThat(serials).isNotEmpty()
+
+        serials.forEachIndexed { index, serial ->
+            withDevice(serial) { dadb ->
+                val devicePort = 39280 + index
+                val expected = "REVERSE-${Random.nextInt(1000, 9999)}"
+                val response =
+                    captureReverseHttpExchange(
+                        serial = serial,
+                        dadb = dadb,
+                        devicePort = devicePort,
+                        responseBody = expected,
+                    ) { url ->
+                        adbShell(serial, "curl -fsS --max-time 5 $url").trim()
+                    }
+
+                assertThat(response).isEqualTo(expected)
+            }
+        }
+    }
+
+    @Test
+    fun reverseSmoke_comparesExternalAdbShellAndDadbShellTriggers() {
+        assertThat(serials).isNotEmpty()
+
+        serials.forEachIndexed { index, serial ->
+            withDevice(serial) { dadb ->
+                val expected = "REVERSE-COMPARE-${Random.nextInt(1000, 9999)}"
+                val externalAdbPayload =
+                    captureReverseHttpExchange(
+                        serial = serial,
+                        dadb = dadb,
+                        devicePort = 39480 + (index * 2),
+                        responseBody = expected,
+                    ) { url ->
+                        adbShell(serial, "curl -fsS --max-time 5 $url").trim()
+                    }
+
+                val dadbShellPayload =
+                    captureReverseHttpExchange(
+                        serial = serial,
+                        dadb = dadb,
+                        devicePort = 39481 + (index * 2),
+                        responseBody = expected,
+                    ) { url ->
+                        val response = dadb.shell("curl -fsS --max-time 5 $url")
+                        assertThat(response.exitCode).isEqualTo(0)
+                        assertThat(response.errorOutput).isEmpty()
+                        response.output.trim()
+                    }
+
+                assertThat(externalAdbPayload).isEqualTo(expected)
+                assertThat(dadbShellPayload).isEqualTo(expected)
+            }
+        }
+    }
+
+    private fun withDevice(
+        serial: String,
+        body: (Dadb) -> Unit,
+    ) {
+        AdbServer.createDadb(
+            adbServerHost = "localhost",
+            adbServerPort = 5037,
+            deviceQuery = "host:transport:$serial",
+            socketTimeout = 5000,
+        ).use(body)
+    }
+
+    private fun adbReverseList(serial: String): String {
+        val process = Runtime.getRuntime().exec(arrayOf("adb", "-s", serial, "reverse", "--list"))
+        val output = process.inputStream.bufferedReader().use { it.readText() }
+        process.waitFor()
+        return output
+    }
+
+    private fun adbShell(
+        serial: String,
+        command: String,
+    ): String {
+        val process = Runtime.getRuntime().exec(arrayOf("adb", "-s", serial, "shell", command))
+        val output = process.inputStream.bufferedReader().use { it.readText() }
+        process.waitFor()
+        return output
+    }
+
+    private fun captureReverseHttpExchange(
+        serial: String,
+        dadb: Dadb,
+        devicePort: Int,
+        responseBody: String,
+        trigger: (url: String) -> String,
+    ): String {
+        ServerSocket(0).use { server ->
+            val hostPort = server.localPort
+            val servedRequest =
+                executor.submit(
+                    Callable<String> {
+                        serveSingleHttpResponse(server, responseBody)
+                    },
+                )
+
+            dadb.reverseForward(devicePort, hostPort)
+            try {
+                val reverseList = adbReverseList(serial)
+                assertThat(reverseList).contains("tcp:$devicePort")
+                assertThat(reverseList).contains("tcp:$hostPort")
+                val deviceUrl = "http://127.0.0.1:$devicePort/"
+                val triggerOutput = trigger(deviceUrl)
+                val request = servedRequest.get(8, TimeUnit.SECONDS)
+                assertThat(request).contains("GET / HTTP")
+                return triggerOutput
+            } finally {
+                runCatching { dadb.reverseKillForward("tcp:$devicePort") }
+            }
+        }
+    }
+
+    private fun serveSingleHttpResponse(
+        server: ServerSocket,
+        responseBody: String,
+    ): String {
+        server.soTimeout = 8000
+        return server.accept().use { socket ->
+            socket.soTimeout = 5000
+            val reader = socket.getInputStream().bufferedReader(Charsets.US_ASCII)
+            val request = StringBuilder()
+
+            while (true) {
+                val line = reader.readLine() ?: break
+                request.append(line).append('\n')
+                if (line.isEmpty()) {
+                    break
+                }
+            }
+
+            val body = responseBody.toByteArray(Charsets.UTF_8)
+            val headers =
+                buildString {
+                    append("HTTP/1.1 200 OK\r\n")
+                    append("Content-Length: ${body.size}\r\n")
+                    append("Connection: close\r\n")
+                    append("\r\n")
+                }.toByteArray(Charsets.US_ASCII)
+
+            socket.getOutputStream().use { output ->
+                output.write(headers)
+                output.write(body)
+                output.flush()
+            }
+
+            request.toString()
+        }
+    }
+}

--- a/dadb/src/test/kotlin/dadb/AdbServerForwardCommandTest.kt
+++ b/dadb/src/test/kotlin/dadb/AdbServerForwardCommandTest.kt
@@ -1,0 +1,66 @@
+package dadb
+
+import com.google.common.truth.Truth.assertThat
+import dadb.adbserver.AdbForwardRule
+import dadb.adbserver.buildHostForwardCommand
+import dadb.adbserver.parseForwardListOutput
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+internal class AdbServerForwardCommandTest {
+
+    @Test
+    fun buildHostForwardCommand_defaultsToGenericHostPrefix() {
+        assertEquals("host:list-forward", buildHostForwardCommand("list-forward"))
+    }
+
+    @Test
+    fun buildHostForwardCommand_supportsSerialScopedHostPrefix() {
+        assertEquals(
+            "host-serial:SERIAL123:killforward:tcp:27183",
+            buildHostForwardCommand("killforward:tcp:27183", serial = "SERIAL123"),
+        )
+    }
+
+    @Test
+    fun buildHostForwardCommand_rejectsBlankCommand() {
+        val error = assertFailsWith<IllegalArgumentException> {
+            buildHostForwardCommand("   ")
+        }
+
+        assertThat(error).hasMessageThat().contains("command must not be blank")
+    }
+
+    @Test
+    fun parseForwardListOutput_parsesAllColumns() {
+        val rules =
+            parseForwardListOutput(
+                """
+                SERIAL123 tcp:27183 localabstract:scrcpy
+                emulator-5554 tcp:27184 tcp:12345
+                """.trimIndent(),
+            )
+
+        assertThat(rules).containsExactly(
+            AdbForwardRule(serial = "SERIAL123", local = "tcp:27183", remote = "localabstract:scrcpy"),
+            AdbForwardRule(serial = "emulator-5554", local = "tcp:27184", remote = "tcp:12345"),
+        )
+    }
+
+    @Test
+    fun parseForwardListOutput_ignoresMalformedRows() {
+        val rules =
+            parseForwardListOutput(
+                """
+                malformed-row
+
+                SERIAL123 tcp:27183 tcp:12345
+                """.trimIndent(),
+            )
+
+        assertThat(rules).containsExactly(
+            AdbForwardRule(serial = "SERIAL123", local = "tcp:27183", remote = "tcp:12345"),
+        )
+    }
+}

--- a/dadb/src/test/kotlin/dadb/AdbServerForwardReverseTest.kt
+++ b/dadb/src/test/kotlin/dadb/AdbServerForwardReverseTest.kt
@@ -1,0 +1,83 @@
+package dadb
+
+import com.google.common.truth.Truth.assertThat
+import dadb.adbserver.AdbServer
+import okio.buffer
+import okio.sink
+import okio.source
+import org.junit.jupiter.api.Assumptions.assumeFalse
+import java.net.ServerSocket
+import java.net.Socket
+import java.util.concurrent.Callable
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import kotlin.test.Test
+
+internal class AdbServerForwardReverseTest {
+
+    private val executor = Executors.newCachedThreadPool()
+    private val realDeviceSerial = findTestRealDeviceSerial()
+
+    @Test
+    fun tcpForward_realDeviceOverAdbServer() {
+        withRealDevice { dadb ->
+            dadb.tcpForward(8891, "tcp:8891").use {
+                val future =
+                    executor.submit {
+                        dadb.shell("echo -e 'OK' | nc -lp 8891")
+                    }
+                Thread.sleep(500)
+
+                val result =
+                    Socket("localhost", 8891).use { socket ->
+                        socket.source().buffer().readUtf8()
+                    }
+
+                future.get(5, TimeUnit.SECONDS)
+                assertThat(result).isEqualTo("OK\n")
+            }
+        }
+    }
+
+    @Test
+    fun reverseForward_realDeviceOverAdbServer() {
+        assumeFalse(
+            realDeviceSerial.contains("_adb-tls-connect._tcp"),
+            "adb reverse over wireless debugging is unreliable; use a USB-connected device for this integration test",
+        )
+
+        withRealDevice { dadb ->
+            val devicePort = 8892
+            ServerSocket(0).use { server ->
+                val hostPort = server.localPort
+                val accepted =
+                    executor.submit(
+                        Callable {
+                            server.accept().use { socket ->
+                                socket.source().buffer().readUtf8LineStrict()
+                            }
+                        },
+                    )
+
+                dadb.reverseForward(devicePort, hostPort)
+
+                try {
+                    val response = dadb.shell("echo -e 'PING' | nc -w 2 127.0.0.1 $devicePort")
+                    assertThat(response.exitCode).isEqualTo(0)
+                    assertThat(accepted.get(5, TimeUnit.SECONDS)).isEqualTo("PING")
+                } finally {
+                    runCatching { dadb.reverseKillForward("tcp:$devicePort") }
+                }
+            }
+        }
+    }
+
+    private fun withRealDevice(body: (Dadb) -> Unit) {
+        AdbServer.createDadb(
+            adbServerHost = "localhost",
+            adbServerPort = 5037,
+            deviceQuery = "host:transport:$realDeviceSerial",
+            socketTimeout = 5000,
+        ).use(body)
+    }
+}

--- a/dadb/src/test/kotlin/dadb/AdbServerHostForwardSmokeTest.kt
+++ b/dadb/src/test/kotlin/dadb/AdbServerHostForwardSmokeTest.kt
@@ -1,0 +1,132 @@
+package dadb
+
+import com.google.common.truth.Truth.assertThat
+import dadb.adbserver.AdbServer
+import dadb.adbserver.forward
+import dadb.adbserver.killForward
+import dadb.adbserver.listForwards
+import okio.buffer
+import okio.source
+import java.io.IOException
+import java.net.Socket
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import kotlin.random.Random
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+
+internal class AdbServerHostForwardSmokeTest {
+
+    private val serials =
+        configuredAdbServerTestSerials()
+            .filter { it in availableAdbDeviceSerials() }
+    private val executor = Executors.newCachedThreadPool()
+
+    @Test
+    fun hostForward_listAndKillForwardSmoke() {
+        assertThat(serials).isNotEmpty()
+
+        serials.forEachIndexed { index, serial ->
+            val devicePort = 39680 + index
+            val expected = "HOST-FORWARD-${Random.nextInt(1000, 9999)}"
+            val listener =
+                executor.submit<String> {
+                    adbShell(serial, buildSingleShotDeviceHttpResponseCommand(devicePort, expected))
+                }
+
+            Thread.sleep(500)
+
+            val assignedPort =
+                checkNotNull(
+                    AdbServer.forward(
+                        local = "tcp:0",
+                        remote = "tcp:$devicePort",
+                        serial = serial,
+                    ),
+                )
+            val localPort = assignedPort.toInt()
+            val localSpec = "tcp:$localPort"
+
+            try {
+                val rules = AdbServer.listForwards(serial = serial)
+                assertThat(rules.any { it.serial == serial && it.local == localSpec && it.remote == "tcp:$devicePort" }).isTrue()
+                assertThat(AdbServer.listForwards().any { it.serial == serial && it.local == localSpec && it.remote == "tcp:$devicePort" }).isTrue()
+
+                val payload = awaitForwardedHttpBody(localPort)
+                assertThat(payload).isEqualTo(expected)
+                assertThat(listener.get(8, TimeUnit.SECONDS)).isEmpty()
+            } finally {
+                runCatching { AdbServer.killForward(localSpec, serial = serial) }
+            }
+
+            val remainingRules = AdbServer.listForwards(serial = serial)
+            assertThat(remainingRules.any { it.local == localSpec }).isFalse()
+        }
+    }
+
+    @Test
+    fun hostForward_noRebindSmoke() {
+        assertThat(serials).isNotEmpty()
+
+        val serial = serials.first()
+        val devicePort = 39780
+        val assignedPort =
+            checkNotNull(
+                AdbServer.forward(
+                    local = "tcp:0",
+                    remote = "tcp:$devicePort",
+                    serial = serial,
+                ),
+            )
+        val localSpec = "tcp:$assignedPort"
+
+        try {
+            val error =
+                assertFailsWith<IOException> {
+                    AdbServer.forward(
+                        local = localSpec,
+                        remote = "tcp:$devicePort",
+                        serial = serial,
+                        noRebind = true,
+                    )
+                }
+
+            assertThat(error).hasMessageThat().contains(localSpec)
+        } finally {
+            runCatching { AdbServer.killForward(localSpec, serial = serial) }
+        }
+    }
+
+    private fun adbShell(
+        serial: String,
+        command: String,
+    ): String {
+        val process = Runtime.getRuntime().exec(arrayOf("adb", "-s", serial, "shell", command))
+        val output = process.inputStream.bufferedReader().use { it.readText() }
+        process.waitFor()
+        return output
+    }
+
+    private fun buildSingleShotDeviceHttpResponseCommand(
+        devicePort: Int,
+        responseBody: String,
+    ): String {
+        return "printf 'HTTP/1.1 200 OK\\r\\nContent-Length: ${responseBody.length}\\r\\nConnection: close\\r\\n\\r\\n$responseBody' | nc -lp $devicePort"
+    }
+
+    private fun awaitForwardedHttpBody(port: Int): String {
+        val deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5)
+        var lastFailure: IOException? = null
+        while (System.nanoTime() < deadline) {
+            try {
+                return Socket("127.0.0.1", port).use { socket ->
+                    socket.source().buffer().readUtf8().substringAfter("\r\n\r\n").trim()
+                }
+            } catch (e: IOException) {
+                lastFailure = e
+                Thread.sleep(200)
+            }
+        }
+        throw lastFailure ?: IOException("Timed out connecting to forwarded port $port")
+    }
+}

--- a/dadb/src/test/kotlin/dadb/AdbStreamTest.kt
+++ b/dadb/src/test/kotlin/dadb/AdbStreamTest.kt
@@ -19,6 +19,7 @@ package dadb
 
 import com.google.common.truth.Truth
 import okio.Buffer
+import kotlin.test.assertFailsWith
 import kotlin.test.Test
 
 internal class AdbStreamTest {
@@ -31,6 +32,124 @@ internal class AdbStreamTest {
         messageQueue.startListening(1)
         val stream = AdbStreamImpl(messageQueue, AdbWriter(Buffer()), 1024, 1, 2)
         Truth.assertThat(stream.source.readByteArray()).isEqualTo(payload)
+    }
+
+    @Test
+    fun sinkWaitsForOkayAfterWrite() {
+        val source = Buffer().apply {
+            AdbWriter(this).write(Constants.CMD_OKAY, 2, 1, null, 0, 0)
+        }
+        val writes = Buffer()
+        val messageQueue = AdbMessageQueue(AdbReader(source))
+        messageQueue.startListening(1)
+        val stream = AdbStreamImpl(messageQueue, AdbWriter(writes), 1024, 1, 2)
+
+        stream.sink.writeUtf8("hello")
+        stream.sink.flush()
+
+        val message = AdbReader(writes).readMessage()
+        Truth.assertThat(message.command).isEqualTo(Constants.CMD_WRTE)
+        Truth.assertThat(message.payload).isEqualTo("hello".toByteArray())
+    }
+
+    @Test
+    fun sinkFailsWhenOkayIsMissing() {
+        val writes = Buffer()
+        val messageQueue = AdbMessageQueue(AdbReader(Buffer()))
+        messageQueue.startListening(1)
+        val stream = AdbStreamImpl(messageQueue, AdbWriter(writes), 1024, 1, 2)
+
+        stream.sink.writeUtf8("hello")
+
+        val error = assertFailsWith<java.io.IOException> {
+            stream.sink.flush()
+        }
+
+        Truth.assertThat(error).hasMessageThat().contains("ADB stream closed before OKAY")
+        val wrte = AdbReader(writes).readMessage()
+        Truth.assertThat(wrte.command).isEqualTo(Constants.CMD_WRTE)
+        Truth.assertThat(writes.exhausted()).isTrue()
+    }
+
+    @Test
+    fun sourceDelayedAckAcknowledgesDeliveredPayload() {
+        val payload = "hello".toByteArray()
+        val writes = Buffer()
+        val messageQueue = AdbMessageQueue(createAdbReader(1, 2, payload))
+        messageQueue.startListening(1)
+        val stream = AdbStreamImpl(
+            messageQueue = messageQueue,
+            adbWriter = AdbWriter(writes),
+            maxPayloadSize = 1024,
+            localId = 1,
+            remoteId = 2,
+            delayedAckEnabled = true,
+        )
+
+        Truth.assertThat(stream.source.readByteArray()).isEqualTo(payload)
+
+        val ack = AdbReader(writes).readMessage()
+        Truth.assertThat(ack.command).isEqualTo(Constants.CMD_OKAY)
+        Truth.assertThat(Constants.decodeOkayAckBytes(ack, delayedAckEnabled = true)).isEqualTo(payload.size)
+        Truth.assertThat(writes.exhausted()).isTrue()
+    }
+
+    @Test
+    fun sinkDelayedAckSplitsWritesByAvailableWindow() {
+        val source = Buffer().apply {
+            AdbWriter(this).writeOkay(2, 1, 2)
+        }
+        val writes = Buffer()
+        val messageQueue = AdbMessageQueue(AdbReader(source))
+        messageQueue.startListening(1)
+        val stream = AdbStreamImpl(
+            messageQueue = messageQueue,
+            adbWriter = AdbWriter(writes),
+            maxPayloadSize = 1024,
+            localId = 1,
+            remoteId = 2,
+            delayedAckEnabled = true,
+            initialAvailableSendBytes = 3,
+        )
+
+        stream.sink.writeUtf8("hello")
+        stream.sink.flush()
+
+        val reader = AdbReader(writes)
+        val firstWrite = reader.readMessage()
+        val secondWrite = reader.readMessage()
+        Truth.assertThat(firstWrite.command).isEqualTo(Constants.CMD_WRTE)
+        Truth.assertThat(String(firstWrite.payload)).isEqualTo("hel")
+        Truth.assertThat(secondWrite.command).isEqualTo(Constants.CMD_WRTE)
+        Truth.assertThat(String(secondWrite.payload)).isEqualTo("lo")
+        Truth.assertThat(writes.exhausted()).isTrue()
+    }
+
+    @Test
+    fun sinkDelayedAckRejectsBareOkayPayload() {
+        val source = Buffer().apply {
+            AdbWriter(this).writeOkay(2, 1)
+        }
+        val writes = Buffer()
+        val messageQueue = AdbMessageQueue(AdbReader(source))
+        messageQueue.startListening(1)
+        val stream = AdbStreamImpl(
+            messageQueue = messageQueue,
+            adbWriter = AdbWriter(writes),
+            maxPayloadSize = 1024,
+            localId = 1,
+            remoteId = 2,
+            delayedAckEnabled = true,
+        )
+
+        stream.sink.writeUtf8("x")
+
+        val error = assertFailsWith<java.io.IOException> {
+            stream.sink.flush()
+        }
+
+        Truth.assertThat(error).hasMessageThat().contains("missing OKAY payload")
+        Truth.assertThat(writes.exhausted()).isTrue()
     }
 
     private fun createAdbReader(localId: Int, remoteId: Int, writePayload: ByteArray): AdbReader {

--- a/dadb/src/test/kotlin/dadb/AdbSyncBehaviorTest.kt
+++ b/dadb/src/test/kotlin/dadb/AdbSyncBehaviorTest.kt
@@ -1,0 +1,211 @@
+package dadb
+
+import com.google.common.truth.Truth.assertThat
+import okio.Buffer
+import java.io.IOException
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+
+internal class AdbSyncBehaviorTest {
+
+    @Test
+    fun send_decodesFailResponse() {
+        val source =
+            Buffer().apply {
+                writeString(FAIL, Charsets.UTF_8)
+                writeIntLe("permission denied".length)
+                writeString("permission denied", Charsets.UTF_8)
+            }
+
+        val stream = bufferBackedStream(source = source, sink = Buffer())
+
+        val error =
+            assertFailsWith<IOException> {
+                AdbSyncStream(stream).use {
+                    it.send(Buffer().writeUtf8("hello"), "/data/local/tmp/hello", 420, 0)
+                }
+            }
+
+        assertThat(error).hasMessageThat().contains("permission denied")
+    }
+
+    @Test
+    fun send_usesSendV2WhenFeaturePresent() {
+        val response =
+            Buffer().apply {
+                writeString(OKAY, Charsets.UTF_8)
+                writeIntLe(0)
+            }
+        val sink = Buffer()
+        val stream = bufferBackedStream(source = response, sink = sink)
+
+        AdbSyncStream(stream, setOf(FEATURE_SENDRECV_V2)).use {
+            it.send(Buffer().writeUtf8("hello"), "/data/local/tmp/hello", 420, 2_000)
+        }
+
+        assertFrameHeader(sink, SEND_V2, 21)
+        assertThat(sink.readUtf8(21L)).isEqualTo("/data/local/tmp/hello")
+        assertFrameHeader(sink, SEND_V2, 420)
+        assertThat(sink.readIntLe()).isEqualTo(0)
+        assertFrameHeader(sink, DATA, 5)
+        assertThat(sink.readUtf8(5L)).isEqualTo("hello")
+        assertFrameHeader(sink, DONE, 2)
+        assertFrameHeader(sink, QUIT, 0)
+        assertThat(sink.exhausted()).isTrue()
+    }
+
+    @Test
+    fun recv_usesRecvV2WhenFeaturePresent() {
+        val source =
+            Buffer().apply {
+                writeString(DATA, Charsets.UTF_8)
+                writeIntLe(5)
+                writeUtf8("hello")
+                writeString(DONE, Charsets.UTF_8)
+                writeIntLe(0)
+            }
+        val sink = Buffer()
+        val stream = bufferBackedStream(source = source, sink = sink)
+        val output = Buffer()
+
+        AdbSyncStream(stream, setOf(FEATURE_SENDRECV_V2)).use {
+            it.recv(output, "/data/local/tmp/hello")
+        }
+
+        assertThat(output.readUtf8()).isEqualTo("hello")
+        assertFrameHeader(sink, RECV_V2, 21)
+        assertThat(sink.readUtf8(21L)).isEqualTo("/data/local/tmp/hello")
+        assertFrameHeader(sink, RECV_V2, 0)
+        assertFrameHeader(sink, QUIT, 0)
+        assertThat(sink.exhausted()).isTrue()
+    }
+
+    @Test
+    fun lstat_usesStatV2WhenFeaturePresent() {
+        val source =
+            Buffer().apply {
+                writeString(LSTAT_V2, Charsets.UTF_8)
+                writeIntLe(0)
+                writeLongLe(1)
+                writeLongLe(2)
+                writeIntLe(33188)
+                writeIntLe(1)
+                writeIntLe(2000)
+                writeIntLe(2000)
+                writeLongLe(123)
+                writeLongLe(10)
+                writeLongLe(20)
+                writeLongLe(30)
+            }
+
+        val stream = bufferBackedStream(source = source, sink = Buffer())
+
+        AdbSyncStream(stream, setOf(FEATURE_STAT_V2)).use {
+            val stat = it.lstat("/data/local/tmp/hello")
+            assertThat(stat.mode).isEqualTo(33188)
+            assertThat(stat.size).isEqualTo(123)
+            assertThat(stat.mtimeSec).isEqualTo(20)
+        }
+    }
+
+    @Test
+    fun list_usesListV2WhenFeaturePresent() {
+        val source =
+            Buffer().apply {
+                writeString(DENT_V2, Charsets.UTF_8)
+                writeIntLe(0)
+                writeLongLe(1)
+                writeLongLe(2)
+                writeIntLe(16877)
+                writeIntLe(1)
+                writeIntLe(2000)
+                writeIntLe(2000)
+                writeLongLe(123)
+                writeLongLe(10)
+                writeLongLe(20)
+                writeLongLe(30)
+                writeIntLe(5)
+                writeUtf8("hello")
+                writeString(DONE, Charsets.UTF_8)
+                write(ByteArray(LIST_V2_DONE_TAIL_BYTES.toInt()))
+            }
+
+        val stream = bufferBackedStream(source = source, sink = Buffer())
+
+        AdbSyncStream(stream, setOf(FEATURE_LS_V2)).use {
+            val entries = it.list("/data/local/tmp")
+            assertThat(entries).hasSize(1)
+            assertThat(entries.first().name).isEqualTo("hello")
+            assertThat(entries.first().mode).isEqualTo(16877)
+            assertThat(entries.first().size).isEqualTo(123)
+            assertThat(entries.first().mtimeSec).isEqualTo(20)
+            assertThat(entries.first().errorCode).isNull()
+        }
+    }
+
+    @Test
+    fun recv_rejectsOversizedDataChunk() {
+        val source =
+            Buffer().apply {
+                writeString(DATA, Charsets.UTF_8)
+                writeIntLe(SYNC_DATA_MAX + 1)
+            }
+
+        val stream = bufferBackedStream(source = source, sink = Buffer())
+
+        val error =
+            assertFailsWith<IOException> {
+                AdbSyncStream(stream).use {
+                    it.recv(Buffer(), "/data/local/tmp/hello")
+                }
+            }
+
+        assertThat(error).hasMessageThat().contains("Sync DATA chunk too large")
+    }
+
+    @Test
+    fun send_rejectsTooLongPath() {
+        val longPath = "/data/local/tmp/" + "a".repeat(SYNC_PATH_MAX + 10)
+        val stream = bufferBackedStream(source = Buffer(), sink = Buffer())
+
+        val error =
+            assertFailsWith<IllegalArgumentException> {
+                AdbSyncStream(stream).use {
+                    it.send(Buffer().writeUtf8("hello"), longPath, 420, 0)
+                }
+            }
+
+        assertThat(error).hasMessageThat().contains("Sync path too long")
+    }
+
+    @Test
+    fun recv_rejectsTooLongPath() {
+        val longPath = "/data/local/tmp/" + "a".repeat(SYNC_PATH_MAX + 10)
+        val stream = bufferBackedStream(source = Buffer(), sink = Buffer())
+
+        val error =
+            assertFailsWith<IllegalArgumentException> {
+                AdbSyncStream(stream).use {
+                    it.recv(Buffer(), longPath)
+                }
+            }
+
+        assertThat(error).hasMessageThat().contains("Sync path too long")
+    }
+
+    private fun bufferBackedStream(
+        source: Buffer,
+        sink: Buffer,
+    ): AdbStream =
+        object : AdbStream {
+            override val source = source
+            override val sink = sink
+
+            override fun close() = Unit
+        }
+
+    private fun assertFrameHeader(buffer: Buffer, id: String, arg: Int) {
+        assertThat(buffer.readString(4L, Charsets.UTF_8)).isEqualTo(id)
+        assertThat(buffer.readIntLe()).isEqualTo(arg)
+    }
+}

--- a/dadb/src/test/kotlin/dadb/AdbWriterTest.kt
+++ b/dadb/src/test/kotlin/dadb/AdbWriterTest.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2021 mobile.dev inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package dadb
+
+import com.google.common.truth.Truth.assertThat
+import okio.Buffer
+import kotlin.test.Test
+
+internal class AdbWriterTest {
+
+    @Test
+    fun write_usesPayloadSliceForChecksumBeforeNegotiation() {
+        val sink = Buffer()
+        val payload = byteArrayOf(1, 2, 3, 4, 5)
+
+        AdbWriter(sink).write(
+            Constants.CMD_WRTE,
+            1,
+            2,
+            payload,
+            1,
+            3,
+        )
+
+        val message = AdbReader(sink).readMessage()
+        assertThat(message.checksum).isEqualTo(2 + 3 + 4)
+        assertThat(message.payload).isEqualTo(byteArrayOf(2, 3, 4))
+    }
+
+    @Test
+    fun write_skipsChecksumAfterNegotiation() {
+        val sink = Buffer()
+        val writer = AdbWriter(sink)
+        writer.updateProtocolVersion(Constants.CONNECT_VERSION)
+
+        val payload = "shell:echo hello".toByteArray()
+        writer.write(
+            Constants.CMD_OPEN,
+            1,
+            0,
+            payload,
+            0,
+            payload.size,
+        )
+
+        val message = AdbReader(sink).readMessage()
+        assertThat(message.checksum).isEqualTo(0)
+    }
+}

--- a/dadb/src/test/kotlin/dadb/DadbImplTest.kt
+++ b/dadb/src/test/kotlin/dadb/DadbImplTest.kt
@@ -18,22 +18,24 @@
 package dadb
 
 import com.google.common.truth.Truth
+import dadb.adbserver.AdbServer
+import okio.Buffer
+import okio.Sink
 import okio.sink
 import okio.source
+import okio.Timeout
+import java.io.IOException
 import java.net.Socket
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
 import kotlin.test.AfterTest
-import kotlin.test.BeforeTest
 import kotlin.test.Ignore
 import kotlin.test.Test
 
 internal class DadbImplTest {
 
-    private val dadb = Dadb.create("localhost", 5555, keyPair = AdbKeyPair.readDefault()) as DadbImpl
-
-    @BeforeTest
-    internal fun setUp() {
-        killServer()
-    }
+    private val endpoint = findTestEmulatorEndpoint()
+    private val dadb = Dadb.create(endpoint.host, endpoint.port, keyPair = AdbKeyPair.readDefault()) as DadbImpl
 
     @AfterTest
     fun tearDown() {
@@ -42,6 +44,7 @@ internal class DadbImplTest {
 
     @Test
     fun reconnection() {
+        killServer()
         assertShellResponse(dadb.shell("echo hello1"), 0, "hello1\n")
 
         dadb.closeConnection()
@@ -51,16 +54,17 @@ internal class DadbImplTest {
 
     @Test
     fun reconnection_customTransport() {
+        killServer()
         val customDadb =
             Dadb.create(
-                description = "localhost:5555",
+                description = "${endpoint.host}:${endpoint.port}",
                 keyPair = AdbKeyPair.readDefault(),
             ) {
-                val socket = Socket("localhost", 5555)
+                val socket = Socket(endpoint.host, endpoint.port)
                 SourceSinkAdbTransport(
                     source = socket.source(),
                     sink = socket.sink(),
-                    description = "localhost:5555",
+                    description = "${endpoint.host}:${endpoint.port}",
                     closeable = socket,
                 )
             } as DadbImpl
@@ -81,12 +85,119 @@ internal class DadbImplTest {
 
     @Test
     fun discover() {
-        val dadb = Dadb.discover("localhost", AdbKeyPair.readDefault(), 1000, 1000) ?: fail("Failed to discover emulator")
-        assertShellResponse(dadb.shell("echo hello"), 0, "hello\n")
+        startServer()
+        val emulatorSerial = checkNotNull(endpoint.serial)
+        val dadb =
+            AdbServer.listDadbs("localhost")
+                .firstOrNull { it.toString() == emulatorSerial }
+                ?: fail("Failed to discover emulator $emulatorSerial")
+        dadb.use {
+            assertShellResponse(it.shell("echo hello"), 0, "hello\n")
+        }
+    }
+
+    @Test
+    fun open_retriesOnceAfterRecoverableStaleTransportFailure() {
+        val connectCount = AtomicInteger(0)
+        val dadb =
+            DadbImpl(
+                transportFactory =
+                    AdbTransportFactory {
+                        val attempt = connectCount.incrementAndGet()
+                        when (attempt) {
+                            1 -> scriptedTransport(respondToOpen = false)
+                            2 -> scriptedTransport(respondToOpen = true)
+                            else -> throw IOException("Unexpected connect attempt $attempt")
+                        }
+                    },
+                keyPair = null,
+            )
+
+        dadb.use {
+            it.open("sync:").use { _ -> }
+        }
+
+        Truth.assertThat(connectCount.get()).isEqualTo(2)
     }
 
     private fun fail(message: String): Nothing {
         Truth.assertWithMessage(message).fail()
         throw RuntimeException()
+    }
+
+    private fun scriptedTransport(respondToOpen: Boolean): AdbTransport {
+        val incoming = Buffer()
+        val payload = "device::features=shell_v2".toByteArray()
+        AdbWriter(incoming).write(
+            Constants.CMD_CNXN,
+            Constants.CONNECT_VERSION,
+            4096,
+            payload,
+            0,
+            payload.size,
+        )
+
+        val closed = AtomicBoolean(false)
+        val outgoing =
+            object : Sink {
+                private val written = Buffer()
+
+                override fun write(
+                    source: Buffer,
+                    byteCount: Long,
+                ) {
+                    written.write(source, byteCount)
+                    while (true) {
+                        val message = readNextMessage(written) ?: break
+                        if (respondToOpen && message.command == Constants.CMD_OPEN) {
+                            val localId = message.arg0
+                            AdbWriter(incoming).write(
+                                Constants.CMD_OKAY,
+                                1,
+                                localId,
+                                null,
+                                0,
+                                0,
+                            )
+                        }
+                    }
+                }
+
+                override fun flush() = Unit
+
+                override fun timeout(): Timeout = Timeout.NONE
+
+                override fun close() {
+                    closed.set(true)
+                }
+            }
+
+        return SourceSinkAdbTransport(
+            source = incoming,
+            sink = outgoing,
+            description = if (respondToOpen) "responsive" else "stale",
+            closeable =
+                AutoCloseable {
+                    closed.set(true)
+                },
+        )
+    }
+
+    private fun readNextMessage(buffer: Buffer): AdbMessage? {
+        if (buffer.size < 24) {
+            return null
+        }
+        val header = buffer.copy()
+        header.readIntLe()
+        header.readIntLe()
+        header.readIntLe()
+        val payloadLength = header.readIntLe()
+        val messageLength = 24L + payloadLength
+        if (buffer.size < messageLength) {
+            return null
+        }
+        val packet = Buffer()
+        packet.write(buffer, messageLength)
+        return AdbReader(packet).readMessage()
     }
 }

--- a/dadb/src/test/kotlin/dadb/DadbImplTest.kt
+++ b/dadb/src/test/kotlin/dadb/DadbImplTest.kt
@@ -18,6 +18,9 @@
 package dadb
 
 import com.google.common.truth.Truth
+import okio.sink
+import okio.source
+import java.net.Socket
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Ignore
@@ -44,6 +47,29 @@ internal class DadbImplTest {
         dadb.closeConnection()
 
         assertShellResponse(dadb.shell("echo hello2"), 0, "hello2\n")
+    }
+
+    @Test
+    fun reconnection_customTransport() {
+        val customDadb =
+            Dadb.create(
+                description = "localhost:5555",
+                keyPair = AdbKeyPair.readDefault(),
+            ) {
+                val socket = Socket("localhost", 5555)
+                SourceSinkAdbTransport(
+                    source = socket.source(),
+                    sink = socket.sink(),
+                    description = "localhost:5555",
+                    closeable = socket,
+                )
+            } as DadbImpl
+
+        customDadb.use {
+            assertShellResponse(it.shell("echo hello1"), 0, "hello1\n")
+            it.closeConnection()
+            assertShellResponse(it.shell("echo hello2"), 0, "hello2\n")
+        }
     }
 
     @Ignore

--- a/dadb/src/test/kotlin/dadb/DadbInstallBehaviorTest.kt
+++ b/dadb/src/test/kotlin/dadb/DadbInstallBehaviorTest.kt
@@ -41,7 +41,7 @@ internal class DadbInstallBehaviorTest {
         val openedDestinations = mutableListOf<String>()
         private val writeSinks = mutableListOf<Buffer>()
 
-        override fun open(destination: String): AdbStream {
+        override fun open(destination: String, enableDelayedAck: Boolean): AdbStream {
             openedDestinations += destination
             val sink = Buffer()
             if (destination.startsWith("abb_exec:package\u0000install-write")) {

--- a/dadb/src/test/kotlin/dadb/DadbInstallBehaviorTest.kt
+++ b/dadb/src/test/kotlin/dadb/DadbInstallBehaviorTest.kt
@@ -1,0 +1,75 @@
+package dadb
+
+import com.google.common.truth.Truth.assertThat
+import okio.Buffer
+import java.nio.file.Files
+import kotlin.test.Test
+
+internal class DadbInstallBehaviorTest {
+
+    @Test
+    fun installMultiple_prefersAbbExecWhenSupported() {
+        val dadb = RecordingInstallDadb(features = setOf("abb_exec", "cmd"))
+        val tempDir = kotlin.io.path.createTempDirectory(prefix = "dadb-install-").toFile().apply { deleteOnExit() }
+        val apk1 = createApk(tempDir, "base.apk", "base")
+        val apk2 = createApk(tempDir, "split.apk", "split")
+
+        listOf(apk1, apk2).forEach {
+            it.deleteOnExit()
+        }
+
+        dadb.installMultiple(listOf(apk1, apk2))
+
+        assertThat(dadb.openedDestinations).containsExactly(
+            "abb_exec:package\u0000install-create\u0000-S\u00009",
+            "abb_exec:package\u0000install-write\u0000-S\u00004\u0000session123\u0000base.apk\u0000-",
+            "abb_exec:package\u0000install-write\u0000-S\u00005\u0000session123\u0000split.apk\u0000-",
+            "abb_exec:package\u0000install-commit\u0000session123",
+        ).inOrder()
+        assertThat(dadb.streamedPayloads()).containsExactly("base", "split").inOrder()
+    }
+
+    private fun createApk(dir: java.io.File, name: String, content: String): java.io.File {
+        val file = java.io.File(dir, name)
+        Files.writeString(file.toPath(), content)
+        return file
+    }
+
+    private class RecordingInstallDadb(
+        private val features: Set<String>,
+    ) : Dadb {
+        val openedDestinations = mutableListOf<String>()
+        private val writeSinks = mutableListOf<Buffer>()
+
+        override fun open(destination: String): AdbStream {
+            openedDestinations += destination
+            val sink = Buffer()
+            if (destination.startsWith("abb_exec:package\u0000install-write")) {
+                writeSinks += sink
+            }
+
+            val response =
+                when {
+                    destination.startsWith("abb_exec:package\u0000install-create") -> "Success: created install session [session123]"
+                    destination.startsWith("abb_exec:package\u0000install-write") -> "Success"
+                    destination.startsWith("abb_exec:package\u0000install-commit") -> "Success"
+                    else -> error("Unexpected destination: $destination")
+                }
+
+            return object : AdbStream {
+                override val source = Buffer().writeUtf8(response)
+                override val sink = sink
+
+                override fun close() = Unit
+            }
+        }
+
+        override fun supportsFeature(feature: String): Boolean = features.contains(feature)
+
+        override fun isTlsConnection(): Boolean = false
+
+        override fun close() = Unit
+
+        fun streamedPayloads(): List<String> = writeSinks.map { it.snapshot().utf8() }
+    }
+}

--- a/dadb/src/test/kotlin/dadb/DadbInstallBehaviorTest.kt
+++ b/dadb/src/test/kotlin/dadb/DadbInstallBehaviorTest.kt
@@ -41,7 +41,7 @@ internal class DadbInstallBehaviorTest {
         val openedDestinations = mutableListOf<String>()
         private val writeSinks = mutableListOf<Buffer>()
 
-        override fun open(destination: String, enableDelayedAck: Boolean): AdbStream {
+        override fun open(destination: String): AdbStream {
             openedDestinations += destination
             val sink = Buffer()
             if (destination.startsWith("abb_exec:package\u0000install-write")) {

--- a/dadb/src/test/kotlin/dadb/DadbShellBehaviorTest.kt
+++ b/dadb/src/test/kotlin/dadb/DadbShellBehaviorTest.kt
@@ -51,7 +51,7 @@ internal class DadbShellBehaviorTest {
     ) : Dadb {
         val openedDestinations = mutableListOf<String>()
 
-        override fun open(destination: String, enableDelayedAck: Boolean): AdbStream {
+        override fun open(destination: String): AdbStream {
             openedDestinations += destination
             val source =
                 Buffer().apply {

--- a/dadb/src/test/kotlin/dadb/DadbShellBehaviorTest.kt
+++ b/dadb/src/test/kotlin/dadb/DadbShellBehaviorTest.kt
@@ -1,0 +1,83 @@
+package dadb
+
+import com.google.common.truth.Truth.assertThat
+import okio.Buffer
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+
+internal class DadbShellBehaviorTest {
+
+    @Test
+    fun shell_usesShellV2WhenSupported() {
+        val dadb = RecordingDadb(supportsShellV2 = true, shellV2Output = "hello\n", exitCode = 0)
+
+        val response = dadb.shell("echo hello")
+
+        assertThat(dadb.openedDestinations).containsExactly("shell,v2,raw:echo hello")
+        assertThat(response.output).isEqualTo("hello\n")
+        assertThat(response.errorOutput).isEmpty()
+        assertThat(response.exitCode).isEqualTo(0)
+    }
+
+    @Test
+    fun shell_fallsBackToLegacyShellWhenShellV2Unsupported() {
+        val dadb = RecordingDadb(supportsShellV2 = false, legacyOutput = "legacy\n")
+
+        val response = dadb.shell("echo hello")
+
+        assertThat(dadb.openedDestinations).containsExactly("shell:echo hello")
+        assertThat(response.output).isEqualTo("legacy\n")
+        assertThat(response.errorOutput).isEmpty()
+        assertThat(response.exitCode).isEqualTo(0)
+    }
+
+    @Test
+    fun openShell_requiresShellV2() {
+        val dadb = RecordingDadb(supportsShellV2 = false, legacyOutput = "unused")
+
+        val error =
+            assertFailsWith<IllegalStateException> {
+                dadb.openShell("echo hello")
+            }
+
+        assertThat(error).hasMessageThat().contains("openShell requires peer feature 'shell_v2'")
+    }
+
+    private class RecordingDadb(
+        private val supportsShellV2: Boolean,
+        private val shellV2Output: String = "",
+        private val legacyOutput: String = "",
+        private val exitCode: Int = 0,
+    ) : Dadb {
+        val openedDestinations = mutableListOf<String>()
+
+        override fun open(destination: String): AdbStream {
+            openedDestinations += destination
+            val source =
+                Buffer().apply {
+                    if (destination.startsWith("shell,v2,raw:")) {
+                        writeByte(ID_STDOUT)
+                        writeIntLe(shellV2Output.toByteArray().size)
+                        writeUtf8(shellV2Output)
+                        writeByte(ID_EXIT)
+                        writeIntLe(1)
+                        writeByte(exitCode)
+                    } else {
+                        writeUtf8(legacyOutput)
+                    }
+                }
+            return object : AdbStream {
+                override val source = source
+                override val sink = Buffer()
+
+                override fun close() = Unit
+            }
+        }
+
+        override fun supportsFeature(feature: String): Boolean = feature == "shell_v2" && supportsShellV2
+
+        override fun isTlsConnection(): Boolean = false
+
+        override fun close() = Unit
+    }
+}

--- a/dadb/src/test/kotlin/dadb/DadbShellBehaviorTest.kt
+++ b/dadb/src/test/kotlin/dadb/DadbShellBehaviorTest.kt
@@ -51,7 +51,7 @@ internal class DadbShellBehaviorTest {
     ) : Dadb {
         val openedDestinations = mutableListOf<String>()
 
-        override fun open(destination: String): AdbStream {
+        override fun open(destination: String, enableDelayedAck: Boolean): AdbStream {
             openedDestinations += destination
             val source =
                 Buffer().apply {

--- a/dadb/src/test/kotlin/dadb/DadbTest.kt
+++ b/dadb/src/test/kotlin/dadb/DadbTest.kt
@@ -20,11 +20,13 @@ package dadb
 import com.google.common.truth.Truth.assertThat
 import okio.Buffer
 import okio.buffer
+import okio.sink
 import okio.source
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
 import java.io.ByteArrayInputStream
 import java.io.FileInputStream
+import java.net.ServerSocket
 import java.net.Socket
 import java.nio.charset.StandardCharsets
 import java.util.*
@@ -283,6 +285,77 @@ internal abstract class DadbTest : BaseConcurrencyTest() {
 
                 assertThat(first).isEqualTo("OK\n")
                 assertThat(second).isEqualTo("OK\n")
+            }
+        }
+    }
+
+    @Test
+    fun tcpForward_remoteDestinationString() {
+        localEmulator { dadb ->
+            dadb.tcpForward(8888, "tcp:8888").use { _ ->
+                val future = broadcastSingleMessage(dadb, "OK", 8888)
+                val result = readSocket("localhost", 8888)
+
+                future.get(1, TimeUnit.SECONDS)
+
+                assertThat(result).isEqualTo("OK\n")
+            }
+        }
+    }
+
+    @Test
+    fun forward_reportsRunningState() {
+        localEmulator { dadb ->
+            val forwarder = dadb.forward(8888, "tcp:8888")
+            assertThat(forwarder.isRunning()).isTrue()
+
+            forwarder.close()
+
+            assertThat(forwarder.isRunning()).isFalse()
+        }
+    }
+
+    @Test
+    fun reverseForward_tcpDeviceToTcpHost() {
+        localEmulator { dadb ->
+            val devicePort = 8890
+            val reverseOutputPath = "/data/local/tmp/dadb-reverse-output"
+            ServerSocket(0).use { server ->
+                val hostPort = server.localPort
+                dadb.reverseForward(devicePort, hostPort)
+
+                try {
+                    val hostToDevice =
+                        executor.submit(
+                            Callable {
+                                server.accept().use { socket ->
+                                    socket.sink().buffer().use { sink ->
+                                        sink.writeUtf8("PONG\n")
+                                        sink.flush()
+                                    }
+                                }
+                            },
+                        )
+                    dadb.shell("rm -f $reverseOutputPath && nc 127.0.0.1 $devicePort > $reverseOutputPath")
+                    hostToDevice.get(5, TimeUnit.SECONDS)
+                    val deviceOutput = dadb.shell("cat $reverseOutputPath")
+                    assertShellResponse(deviceOutput, 0, "PONG\n")
+
+                    val deviceToHost =
+                        executor.submit(
+                            Callable {
+                                server.accept().use { socket ->
+                                    socket.source().buffer().readUtf8LineStrict()
+                                }
+                            },
+                        )
+                    val sendResponse = dadb.shell("echo -e 'PING' | nc 127.0.0.1 $devicePort")
+                    assertThat(sendResponse.exitCode).isEqualTo(0)
+                    assertThat(deviceToHost.get(5, TimeUnit.SECONDS)).isEqualTo("PING")
+                } finally {
+                    runCatching { dadb.shell("rm -f $reverseOutputPath") }
+                    runCatching { dadb.reverseKillForward("tcp:$devicePort") }
+                }
             }
         }
     }

--- a/dadb/src/test/kotlin/dadb/DadbTestImpl.kt
+++ b/dadb/src/test/kotlin/dadb/DadbTestImpl.kt
@@ -21,11 +21,13 @@ internal class DadbTestImpl : DadbTest() {
         private val connection: AdbConnection,
     ) : Dadb {
 
-        override fun open(destination: String, enableDelayedAck: Boolean) = connection.open(destination, enableDelayedAck)
+        override fun open(destination: String) = connection.open(destination)
 
         override fun supportsFeature(feature: String) = connection.supportsFeature(feature)
 
         override fun isTlsConnection() = connection.isTlsConnection()
+
+        override fun reconnect(withDelayedAck: Boolean) = Unit
 
         override fun close() = connection.close()
     }

--- a/dadb/src/test/kotlin/dadb/DadbTestImpl.kt
+++ b/dadb/src/test/kotlin/dadb/DadbTestImpl.kt
@@ -27,8 +27,6 @@ internal class DadbTestImpl : DadbTest() {
 
         override fun isTlsConnection() = connection.isTlsConnection()
 
-        override fun reconnect(withDelayedAck: Boolean) = Unit
-
         override fun close() = connection.close()
     }
 

--- a/dadb/src/test/kotlin/dadb/DadbTestImpl.kt
+++ b/dadb/src/test/kotlin/dadb/DadbTestImpl.kt
@@ -21,7 +21,7 @@ internal class DadbTestImpl : DadbTest() {
         private val connection: AdbConnection,
     ) : Dadb {
 
-        override fun open(destination: String) = connection.open(destination)
+        override fun open(destination: String, enableDelayedAck: Boolean) = connection.open(destination, enableDelayedAck)
 
         override fun supportsFeature(feature: String) = connection.supportsFeature(feature)
 

--- a/dadb/src/test/kotlin/dadb/DadbTestImpl.kt
+++ b/dadb/src/test/kotlin/dadb/DadbTestImpl.kt
@@ -23,6 +23,8 @@ internal class DadbTestImpl : DadbTest() {
 
         override fun supportsFeature(feature: String) = connection.supportsFeature(feature)
 
+        override fun isTlsConnection() = connection.isTlsConnection()
+
         override fun close() = connection.close()
     }
 

--- a/dadb/src/test/kotlin/dadb/DadbTestImpl.kt
+++ b/dadb/src/test/kotlin/dadb/DadbTestImpl.kt
@@ -7,8 +7,10 @@ import kotlin.test.assertNotNull
 
 internal class DadbTestImpl : DadbTest() {
 
+    private val endpoint = findTestEmulatorEndpoint()
+
     override fun localEmulator(body: (dadb: Dadb) -> Unit) {
-        val socket = Socket("localhost", 5555)
+        val socket = Socket(endpoint.host, endpoint.port)
         val keyPair = AdbKeyPair.readDefault()
         val connection = AdbConnection.connect(socket, keyPair)
         TestDadb(connection).use(body)
@@ -30,14 +32,14 @@ internal class DadbTestImpl : DadbTest() {
 
     @Test
     fun validDefaultConstructorValues() {
-        val dadb = Dadb.create("localhost", 5555)
+        val dadb = Dadb.create(endpoint.host, endpoint.port)
         assertNotNull(dadb, "Unable to create Dadb object with default constructor values")
     }
 
 
     @Test
     fun validConstructorValues() {
-        val dadb = Dadb.create("localhost", 5555, connectTimeout = 1000, socketTimeout = 10000)
+        val dadb = Dadb.create(endpoint.host, endpoint.port, connectTimeout = 1000, socketTimeout = 10000)
         assertNotNull(dadb, "Unable to create Dadb object with valid constructor values")
     }
 
@@ -51,14 +53,14 @@ internal class DadbTestImpl : DadbTest() {
     @Test
     fun invalidconnectTimeoutConstructorValue() {
         assertFails("Invalid connectTimeout value was not validated") {
-            Dadb.create("localhost", 5555, connectTimeout = -1, socketTimeout = 0)
+            Dadb.create(endpoint.host, endpoint.port, connectTimeout = -1, socketTimeout = 0)
         }
     }
 
     @Test
     fun invalidSocketTimeoutConstructorValue() {
         assertFails("Invalid socketTimeout value was not validated") {
-            Dadb.create("localhost", 5555, connectTimeout = 0, socketTimeout = -1)
+            Dadb.create(endpoint.host, endpoint.port, connectTimeout = 0, socketTimeout = -1)
         }
     }
 

--- a/dadb/src/test/kotlin/dadb/TestUtils.kt
+++ b/dadb/src/test/kotlin/dadb/TestUtils.kt
@@ -19,6 +19,7 @@ package dadb
 
 import com.google.common.truth.Truth
 import java.io.IOException
+import java.util.regex.Pattern
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.TimeUnit
 
@@ -43,6 +44,152 @@ fun startServer() {
     try {
         Runtime.getRuntime().exec("adb start-server").waitFor()
     } catch (ignore: IOException) {}
+}
+
+data class TestEmulatorEndpoint(
+    val host: String,
+    val port: Int,
+    val serial: String?,
+)
+
+fun findTestRealDeviceSerial(): String {
+    val configuredSerial = System.getenv("DADB_TEST_REAL_DEVICE_SERIAL")
+    if (!configuredSerial.isNullOrBlank()) {
+        return configuredSerial
+    }
+
+    val process = Runtime.getRuntime().exec(arrayOf("adb", "devices"))
+    val output = process.inputStream.bufferedReader().use { it.readText() }
+    process.waitFor()
+
+    return output
+        .lineSequence()
+        .map { it.trim() }
+        .filter { it.isNotBlank() && !it.startsWith("List of devices attached") }
+        .mapNotNull { line ->
+            val parts = line.split(Regex("\\s+"))
+            val serial = parts.firstOrNull() ?: return@mapNotNull null
+            val state = parts.getOrNull(1) ?: return@mapNotNull null
+            if (state != "device" || serial.startsWith("emulator-")) {
+                null
+            } else {
+                serial
+            }
+        }
+        .firstOrNull()
+        ?: throw IllegalStateException(
+            "No real Android device found. Set DADB_TEST_REAL_DEVICE_SERIAL or connect one device via adb server.",
+        )
+}
+
+fun configuredAdbServerTestSerials(): List<String> {
+    val configured = System.getenv("DADB_TEST_SERIALS")
+        ?.split(',')
+        ?.map { it.trim() }
+        ?.filter { it.isNotEmpty() }
+        .orEmpty()
+    if (configured.isNotEmpty()) {
+        return configured
+    }
+
+    val process = Runtime.getRuntime().exec(arrayOf("adb", "devices"))
+    val output = process.inputStream.bufferedReader().use { it.readText() }
+    process.waitFor()
+
+    return output
+        .lineSequence()
+        .map { it.trim() }
+        .filter { it.isNotBlank() && !it.startsWith("List of devices attached") }
+        .mapNotNull { line ->
+            val parts = line.split(Regex("\\s+"))
+            val serial = parts.firstOrNull() ?: return@mapNotNull null
+            val state = parts.getOrNull(1) ?: return@mapNotNull null
+            if (state == "device") serial else null
+        }
+        .toList()
+}
+
+fun availableAdbDeviceSerials(): Set<String> {
+    val process = Runtime.getRuntime().exec(arrayOf("adb", "devices"))
+    val output = process.inputStream.bufferedReader().use { it.readText() }
+    process.waitFor()
+
+    return output
+        .lineSequence()
+        .map { it.trim() }
+        .filter { it.isNotBlank() && !it.startsWith("List of devices attached") }
+        .mapNotNull { line ->
+            val parts = line.split(Regex("\\s+"))
+            val serial = parts.firstOrNull() ?: return@mapNotNull null
+            val state = parts.getOrNull(1) ?: return@mapNotNull null
+            if (state == "device") serial else null
+        }
+        .toSet()
+}
+
+fun findConnectedDeviceSerials(): List<String> {
+    val process = Runtime.getRuntime().exec(arrayOf("adb", "devices"))
+    val output = process.inputStream.bufferedReader().use { it.readText() }
+    process.waitFor()
+
+    return output
+        .lineSequence()
+        .map { it.trim() }
+        .filter { it.isNotBlank() && !it.startsWith("List of devices attached") }
+        .mapNotNull { line ->
+            val parts = line.split(Regex("\\s+"))
+            if (parts.size >= 2 && parts[1] == "device") {
+                parts[0]
+            } else {
+                null
+            }
+        }
+        .toList()
+}
+
+fun findServerSmokeDeviceSerials(): List<String> {
+    val configured = System.getenv("DADB_TEST_SERIALS")
+        ?.split(',')
+        ?.map { it.trim() }
+        ?.filter { it.isNotEmpty() }
+        .orEmpty()
+    return if (configured.isNotEmpty()) {
+        configured
+    } else {
+        findConnectedDeviceSerials()
+    }
+}
+
+fun findTestEmulatorEndpoint(): TestEmulatorEndpoint {
+    val configuredPort = System.getenv("DADB_TEST_EMULATOR_PORT")?.toIntOrNull()
+    if (configuredPort != null && configuredPort > 0) {
+        return TestEmulatorEndpoint(
+            host = System.getenv("DADB_TEST_EMULATOR_HOST") ?: "localhost",
+            port = configuredPort,
+            serial = System.getenv("DADB_TEST_EMULATOR_SERIAL"),
+        )
+    }
+
+    val process =
+        Runtime.getRuntime().exec(arrayOf("adb", "devices"))
+    val output =
+        process.inputStream.bufferedReader().use { it.readText() }
+    process.waitFor()
+
+    val emulatorPattern = Pattern.compile("^emulator-(\\d+)\\s+device$", Pattern.MULTILINE)
+    val matcher = emulatorPattern.matcher(output)
+    if (matcher.find()) {
+        val consolePort = matcher.group(1).toInt()
+        return TestEmulatorEndpoint(
+            host = "localhost",
+            port = consolePort + 1,
+            serial = "emulator-$consolePort",
+        )
+    }
+
+    throw IllegalStateException(
+        "No emulator device found. Set DADB_TEST_EMULATOR_PORT or start an Android emulator before running direct dadb tests.",
+    )
 }
 
 fun CompletableFuture<*>.waitFor() {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -6,6 +6,7 @@ pluginManagement {
     }
 }
 
+@Suppress("UnstableApiUsage")
 dependencyResolutionManagement {
     repositories {
         google()

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -16,3 +16,4 @@ dependencyResolutionManagement {
 rootProject.name = "dadb"
 include("dadb")
 include("dadb-android")
+include("dadb-helper")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,2 +1,18 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolutionManagement {
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
 rootProject.name = "dadb"
 include("dadb")
+include("dadb-android")


### PR DESCRIPTION
Since I don't have much time to process this PR, I hope the author can take a moment to look at it. I'm currently dealing with coupling issues in my own project.


ISSUES：Add support for USB Android API #95

Welcome to Codex. Let Codex handle the tasks according to your project requirements and your development style. I used two Android devices connected via Type-C to create a simple Android app to test the USB connection.

A friendly reminder: when connecting two Android devices, file management permissions are required. Software cannot monitor the permission status; the correct approach is to refresh rather than wait for a callback.