### PR TITLE
fix: prevent stream localId collisions from destroying live stream state

### DIFF
--- a/dadb/src/main/kotlin/dadb/AdbConnection.kt
+++ b/dadb/src/main/kotlin/dadb/AdbConnection.kt
@@ -25,7 +25,7 @@ import org.jetbrains.annotations.TestOnly
 import java.io.Closeable
 import java.io.IOException
 import java.net.Socket
-import java.util.*
+import java.util.concurrent.atomic.AtomicInteger
 
 internal class AdbConnection internal constructor(
         adbReader: AdbReader,
@@ -36,7 +36,7 @@ internal class AdbConnection internal constructor(
         private val maxPayloadSize: Int
 ) : AutoCloseable {
 
-    private val random = Random()
+    private val nextLocalId = AtomicInteger(0)
     private val messageQueue = AdbMessageQueue(adbReader)
 
     @Throws(IOException::class)
@@ -58,8 +58,11 @@ internal class AdbConnection internal constructor(
         return supportedFeatures.contains(feature)
     }
 
+    // Sequential like AOSP's adb client. Random ints can collide with an ID
+    // already in use; the colliding stream's close then destroys the live
+    // stream's message queue ("Not listening for localId").
     private fun newId(): Int {
-        return random.nextInt()
+        return nextLocalId.incrementAndGet()
     }
 
     @TestOnly

--- a/dadb/src/main/kotlin/dadb/MessageQueue.kt
+++ b/dadb/src/main/kotlin/dadb/MessageQueue.kt
@@ -46,7 +46,7 @@ internal abstract class MessageQueue<V> {
     }
 
     fun startListening(localId: Int) {
-        openStreams.add(localId)
+        check(openStreams.add(localId)) { "Already listening for localId: $localId" }
         queues.putIfAbsent(localId, ConcurrentHashMap())
     }
 
@@ -70,7 +70,7 @@ internal abstract class MessageQueue<V> {
     protected abstract fun isCloseCommand(message: V): Boolean
 
     private fun poll(localId: Int, command: Int): V? {
-        val streamQueues = queues[localId] ?: throw IllegalStateException("Not listening for localId: $localId")
+        val streamQueues = queues[localId] ?: throw AdbStreamClosed(localId)
         val message = streamQueues[command]?.poll()
         if (message == null && !openStreams.contains(localId)) {
             throw AdbStreamClosed(localId)

--- a/dadb/src/test/kotlin/dadb/MessageQueueTest.kt
+++ b/dadb/src/test/kotlin/dadb/MessageQueueTest.kt
@@ -22,6 +22,7 @@ import java.util.concurrent.LinkedBlockingDeque
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.test.Test
 import kotlin.test.BeforeTest
+import kotlin.test.assertFailsWith
 
 internal class MessageQueueTest : BaseConcurrencyTest() {
 
@@ -46,6 +47,28 @@ internal class MessageQueueTest : BaseConcurrencyTest() {
 
         take(0, 0)
         take(1, 0)
+    }
+
+    @Test
+    fun startListening_rejectsLocalIdAlreadyInUse() {
+        // Two streams listening on the same localId share a single queues entry.
+        // The first one to close removes that entry and the survivor's next
+        // take() dies with "Not listening for localId", even though it was
+        // never closed. Registering a duplicate must fail loudly instead.
+        assertFailsWith<IllegalStateException> {
+            messageQueue.startListening(0)
+        }
+    }
+
+    @Test
+    fun take_afterStopListening_throwsAdbStreamClosed() {
+        messageQueue.stopListening(1)
+
+        // A stream that is gone should surface as the graceful AdbStreamClosed
+        // (which callers already handle), not IllegalStateException.
+        assertFailsWith<AdbStreamClosed> {
+            messageQueue.take(1, 0)
+        }
     }
 
     @Test


### PR DESCRIPTION
## What this looks like in production

DuckDuckGo (and 20+ other orgs over the last 14 days, internal ref: MA-4060) run Maestro flows with `androidWebViewHierarchy: devtools`, which fetches WebView hierarchies over Chrome DevTools using short-lived streams (HTTP + websocket via OkHttp) on the same `Dadb` connection the driver uses for taps. Their flows fail on **native** taps that already matched: the tap is issued, and the command then dies with:

```
CommandFailed: Not listening for localId: 1844909876
```

For the affected flows this failed 4 out of 4 attempts across 4 different hosts. The exception escapes the devtools client's `catch (e: IOException)` (it is an `IllegalStateException`) and fails the customer's command.

## Root cause

`MessageQueue` keys all stream state on the raw `localId` int, and `stopListening(localId)` removes it without holding any lock. There are two ways a live stream's state gets destroyed:

**1. Close-during-read race (no collision needed, the frequent path).** `AdbStreamImpl.nextMessage` already handles "stream closed while reading" gracefully:

```kotlin
private fun nextMessage(command: Int): AdbMessage? {
    return try {
        messageQueue.take(localId, command)
    } catch (e: IOException) {   // AdbStreamClosed is an IOException -> clean EOF
        close()
        return null
    }
}
```

But if another thread calls `close()` (-> `stopListening`) while a reader is blocked inside `take()`, the next `poll()` finds `queues[localId] == null` and throws `IllegalStateException("Not listening for localId")` instead of `AdbStreamClosed`. Not an `IOException`, so it escapes the catch above and every caller's IO error handling. OkHttp closes sockets from watchdog/cancellation/pool-eviction threads while its reader threads are blocked, so the devtools path hits this interleaving routinely.

**2. localId collision (rare, the latent design flaw).** `AdbConnection.newId()` is `random.nextInt()` with no uniqueness check. If two concurrently-open streams draw the same ID, `startListening` silently no-ops (`putIfAbsent`) and both streams share one state entry; the first to close wipes the survivor's state and its next `take()` throws the same fatal exception.

## Changes

1. **Sequential stream IDs** (`AtomicInteger`), like AOSP's adb client. Collisions within a connection become impossible.
2. **`startListening` fails fast on a duplicate ID** instead of silently sharing one state entry between two streams.
3. **A missing queue entry in `poll()` now throws `AdbStreamClosed`** instead of `IllegalStateException`. This makes the close-during-read race resolve through the existing `IOException` handling as a normal end-of-stream, which is what "the stream was closed under you" should mean.

## Testing

The new tests in `MessageQueueTest` fail on master and pass with this change. The full `MessageQueueTest` suite (including the existing concurrency stress tests) passes. Device-dependent tests (`DadbTest`) were not run locally and rely on CI.