### PR TITLE
chore: prepare 2.0.0 release (version + changelog)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 * **Breaking:** a connection dropped mid-stream now throws `AdbConnectionClosedException` instead of presenting as a clean end-of-stream.
 * **Breaking:** a read or write that exceeds its timeout now throws `AdbTimeoutException` instead of a raw `SocketTimeoutException`.
 * `pmInstall` (the non-`cmd` install path) now checks the `pm install` result instead of ignoring it.
+* Fixed stream local-id collisions that surfaced as `Not listening for localId` and could tear down a live stream's state; stream ids are now sequential, like AOSP's adb client.
+* Socket writes are now bounded by a write timeout, so a wedged device fails fast instead of blocking a write indefinitely; the connection is rebuilt on the next operation.
+* A stream read parked in `MessageQueue.take()` no longer hangs when the connection closes or a read fails; it now wakes with the relevant `AdbException`.
 * Added opt-in result helpers — `onSuccess`/`onFailure`/`orThrow` on each `…Result` type. `orThrow` raises `AdbOperationFailedException`, which is **not** an `AdbException`, so a transport-level `catch (AdbException)` won't catch an opted-in operation-failure throw.
 
 ### 1.2.10

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=dev.mobile
-VERSION_NAME=1.2.10
+VERSION_NAME=2.0.0
 POM_DESCRIPTION=A library to communicate directly with Android devices over ADB without an ADB server
 POM_URL=https://github.com/mobile-dev-inc/dadb
 POM_SCM_URL=https://github.com/mobile-dev-inc/dadb


### PR DESCRIPTION
Prepares the dadb 2.0.0 release. Two changes:

**Version bump:** `VERSION_NAME` 1.2.10 to 2.0.0 (major, for the breaking error-model change).

**Completed CHANGELOG:** the 2.0.0 entry landed with #101 but only described the error-model redesign. This adds the other changes shipping since `v1.2.10`:
- #102: localId-collision fix (the `Not listening for localId` error)
- #99: socket writes now bounded by a write timeout
- #100: parked stream reader wakes on close / read failure instead of hanging

Cross-checked against `git log v1.2.10..master`: the four PRs in 2.0.0 are #99, #100, #101, #102, and all four are now in the notes.
