### PR TITLE
fix(ci): publish-release uses the MavenCentral secrets present in the repo

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -7,8 +7,8 @@ on:
       - 'v*'
 
 env:
-  ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
-  ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
+  ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.ORG_GRADLE_PROJECT_MAVENCENTRALUSERNAME }}
+  ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.ORG_GRADLE_PROJECT_MAVENCENTRALPASSWORD }}
 
 jobs:
   publish:


### PR DESCRIPTION
## What

Point the Publish Release workflow at the Maven Central credentials that actually exist in the repo.

```diff
-  ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
-  ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
+  ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.ORG_GRADLE_PROJECT_MAVENCENTRALUSERNAME }}
+  ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.ORG_GRADLE_PROJECT_MAVENCENTRALPASSWORD }}
```

## Why

The v2.0.0 publish failed at the upload step with `{"error":{"message":"Invalid token"}}`. Build and signing succeed; only the Sonatype upload fails. In the run logs the credential env vars resolve to empty (blank, not masked as `***`), so `secrets.SONATYPE_NEXUS_USERNAME` / `SONATYPE_NEXUS_PASSWORD` are not set and an empty bearer token is sent.

The repo's real Maven Central creds live under `ORG_GRADLE_PROJECT_MAVENCENTRALUSERNAME` / `ORG_GRADLE_PROJECT_MAVENCENTRALPASSWORD` (set 2025-10-01), which the workflow never referenced. That is also why every prior `v1.2.10` tag run failed the same way; the only green publish in the workflow history was a one-off manual dispatch on the `signing` branch.

Confirmed with Amanjeet (who cut the last release) that these are the correct secret names.

## After merge

Nothing is on Central yet (the upload was rejected, no artifact shipped) and the `v2.0.0` tag is intact. To publish 2.0.0, run Publish Release via `workflow_dispatch` from `master` (which has `VERSION_NAME=2.0.0`); the job reads the version from `gradle.properties`, so no tag re-push is needed.
