### PR TITLE
fix: sign publications so Maven Central accepts the deployment

### DIFF
--- a/dadb/build.gradle.kts
+++ b/dadb/build.gradle.kts
@@ -28,4 +28,5 @@ tasks.test {
 
 mavenPublishing {
     publishToMavenCentral(true)
+    signAllPublications()
 }


### PR DESCRIPTION
## What

Add `signAllPublications()` so release artifacts are GPG-signed.

```diff
 mavenPublishing {
     publishToMavenCentral(true)
+    signAllPublications()
 }
```

## Why

After #104 fixed the publish credentials, the 2.0.0 publish run goes green but the artifact never appears on Maven Central. Cause: master never signs its artifacts, and the Central Portal rejects unsigned deployments in validation, so the upload succeeds (green build) while the deployment never releases. That is why 2.0.0 still 404s and the `maven-metadata.xml` is frozen at 1.2.10.

Verified locally on a fresh clone:
- `publishToMavenLocal` on master produces jar / sources / javadoc / pom / module and **zero `.asc`** signatures.
- The publish task graph on master has no `signMavenPublication` task; the green 2.0.0 CI run's task list confirms signing never ran.
- Adding this line wires `signMavenPublication` into the publish pipeline; with a key it produces a valid `.asc` for every artifact (5 of them), and `gpg --verify` on the jar signature returns `Good signature`.

This restores parity with the commit that successfully published 1.2.10 (`87ece684`), which had `signAllPublications()` plus the same plugin (0.33.0), task (`publishToMavenCentral`), and host config. The signing key is already provided to the workflow via `SIGNING_PRIVATE_KEY`; it was simply unused without this line.

## After merge

Re-dispatch Publish Release from `master` (it has `VERSION_NAME=2.0.0`); the signed artifacts should pass Central validation and release.
