### PR TITLE
Fix checksum for partial ADB payload writes

### DIFF
--- a/dadb/src/main/kotlin/dadb/AdbWriter.kt
+++ b/dadb/src/main/kotlin/dadb/AdbWriter.kt
@@ -86,7 +86,7 @@ internal class AdbWriter(sink: Sink) : AutoCloseable {
                         writeIntLe(0)
                     } else {
                         writeIntLe(length)
-                        writeIntLe(payloadChecksum(payload))
+                        writeIntLe(payloadChecksum(payload, offset, length))
                     }
                     writeIntLe(command xor -0x1)
                     if (payload != null) {
@@ -110,10 +110,10 @@ internal class AdbWriter(sink: Sink) : AutoCloseable {
 
     companion object {
 
-        private fun payloadChecksum(payload: ByteArray): Int {
+        private fun payloadChecksum(payload: ByteArray, offset: Int, length: Int): Int {
             var checksum = 0
-            for (byte in payload) {
-                checksum += byte.toUByte().toInt()
+            for (index in offset until offset + length) {
+                checksum += payload[index].toUByte().toInt()
             }
             return checksum
         }

--- a/dadb/src/test/kotlin/dadb/AdbWriterTest.kt
+++ b/dadb/src/test/kotlin/dadb/AdbWriterTest.kt
@@ -37,6 +37,23 @@ internal class AdbWriterTest {
     }
 
     @Test
+    fun payloadChecksum_coversOnlyWrittenRange() {
+        val output = Buffer()
+        val writer = AdbWriter(output)
+        val payload = byteArrayOf(10, 20, 30, 40, 50)
+
+        writer.writeWrite(localId = 1, remoteId = 2, payload = payload, offset = 1, length = 2)
+
+        assertThat(output.readIntLe()).isEqualTo(Constants.CMD_WRTE)
+        assertThat(output.readIntLe()).isEqualTo(1)
+        assertThat(output.readIntLe()).isEqualTo(2)
+        assertThat(output.readIntLe()).isEqualTo(2)
+        assertThat(output.readIntLe()).isEqualTo(20 + 30)
+        assertThat(output.readIntLe()).isEqualTo(Constants.CMD_WRTE xor -0x1)
+        assertThat(output.readByteArray()).isEqualTo(byteArrayOf(20, 30))
+    }
+
+    @Test
     fun payloadWrite_onWriteTimeout_surfacesAsAdbTimeout() {
         // The wedged-push path: AdbStream.sink.flush() -> writeWrite(...). okio's write timeout on a
         // stalled adbd is a timeout, not a dropped connection, so it surfaces as AdbTimeoutException.


### PR DESCRIPTION
  Fix a regression in ADB `WRTE` checksums for partial payloads.

  After the reusable-buffer write path was introduced, `AdbWriter` calculated the checksum over the entire backing buffer while transmitting only `offset` and `length`. Stale bytes caused older adbd versions to reject the packet and close the connection, affecting both push and streamed install.

  The checksum now covers only the transmitted range. A regression test is included.

  Validated with unit tests, SYNC push, and APK import on Android 8.1.

  Closes #56